### PR TITLE
fix: change archive string in Settings from verb to noun

### DIFF
--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -356,7 +356,7 @@
                 style="@style/SettingsSectionLabelStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/archive" />
+                android:text="@string/archived_conversations" />
 
             <RelativeLayout
                 android:id="@+id/settings_keep_conversations_archived_holder"


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- `@string/archive`  is used in the app as a verb, but here it was used as a noun. While it doesn't seem like an issue in English, it leads to wrong translations to other languages.
- Replaced the section title in Settings to `@string/archived_conversations` which is also `Archive`, but this one is used everywhere as a noun.

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
