### PR TITLE
fix: update send button state when compression is skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed keyword blocking for MMS messages ([#99])
 - Fixed contact number selection when adding members to a group ([#456])
 - Fixed a glitch in pattern lock after incorrect attempts
+- Fixed disabled send button when sending images without text ([#165])
 
 ## [1.3.0] - 2025-09-09
 ### Added
@@ -158,6 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#334]: https://github.com/FossifyOrg/Messages/issues/334
 [#349]: https://github.com/FossifyOrg/Messages/issues/349
 [#359]: https://github.com/FossifyOrg/Messages/issues/359
+[#165]: https://github.com/FossifyOrg/Messages/issues/165
 [#456]: https://github.com/FossifyOrg/Messages/issues/456
 [#461]: https://github.com/FossifyOrg/Messages/issues/461
 

--- a/app/src/main/kotlin/org/fossify/messages/adapters/AttachmentsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/messages/adapters/AttachmentsAdapter.kt
@@ -160,6 +160,10 @@ class AttachmentsAdapter(
                     }
                 }
             } else {
+                if (attachment.isPending) {
+                    attachments.find { it.uri == attachment.uri }?.isPending = false
+                    onReady()
+                }
                 loadMediaPreview(this, attachment)
             }
         }


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Updated button state when image compression is skipped due to **No limit** size preference.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Attaching images without text
 
#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Messages/issues/165

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
