### PR TITLE
feat: show seconds in the message properties dialog (#260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimized loading messages in conversations
 - Updated conversation item design to be more compact ([#376])
 - Pin/unpin actions now always show as action buttons in menu ([#561])
+- Added showing seconds in the message properties dialog ([#260])
 
 ### Fixed
 - Fixed position reset when opening attachments in conversations ([#82])
@@ -168,6 +169,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#217]: https://github.com/FossifyOrg/Messages/issues/217
 [#225]: https://github.com/FossifyOrg/Messages/issues/225
 [#243]: https://github.com/FossifyOrg/Messages/issues/243
+[#260]: https://github.com/FossifyOrg/Messages/issues/260
 [#262]: https://github.com/FossifyOrg/Messages/issues/262
 [#264]: https://github.com/FossifyOrg/Messages/issues/264
 [#274]: https://github.com/FossifyOrg/Messages/issues/274

--- a/app/src/main/kotlin/org/fossify/messages/dialogs/MessageDetailsDialog.kt
+++ b/app/src/main/kotlin/org/fossify/messages/dialogs/MessageDetailsDialog.kt
@@ -6,6 +6,7 @@ import org.fossify.commons.activities.BaseSimpleActivity
 import org.fossify.commons.dialogs.BasePropertiesDialog
 import org.fossify.commons.extensions.getAlertDialogBuilder
 import org.fossify.commons.extensions.getTimeFormat
+import org.fossify.commons.extensions.getTimeFormatWithSeconds
 import org.fossify.commons.extensions.setupDialogStuff
 import org.fossify.messages.R
 import org.fossify.messages.extensions.config
@@ -71,6 +72,6 @@ class MessageDetailsDialog(val activity: BaseSimpleActivity, val message: Messag
     }
 
     private fun Message.getSentOrReceivedAt(): String {
-        return DateTime(date * 1000L).toString("${activity.config.dateFormat} ${activity.getTimeFormat()}")
+        return DateTime(date * 1000L).toString("${activity.config.dateFormat} ${activity.getTimeFormatWithSeconds()}")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ eventbus = "3.3.1"
 #Room
 room = "2.8.2"
 #Fossify
-commons = "5.3.1"
+commons = "5.4.0"
 mmslib = "1.0.0"
 indicator-fast-scroll = "4524cd0b61"
 #Gradle


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [X] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Used a new function from commons for proper time formatting, which includes seconds.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Opened message properties dialog for incoming message.
 - Opened message properties dialog for outgoing message.
 - Opened message properties dialog while having locale with 24h time format (Poland) and 12h time format (US).

#### Before & after preview
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->

<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/a92736c8-dd21-4716-b4f4-fcbc5aee1200" width=179 />

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #260

#### Checklist
- [X] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [X] I manually tested my changes on device/emulator (if applicable).
- [X] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [X] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
