### PR TITLE
perf: improve mark as read performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-
 - Compatibility updates for Android 15 & 16
 - Calling now works directly without launching dialpad ([#562])
+
+### Fixed
+- Fixed freezing when sending messages ([#574])
 
 ## [1.5.0] - 2025-10-18
 ### Added
@@ -194,6 +196,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#461]: https://github.com/FossifyOrg/Messages/issues/461
 [#561]: https://github.com/FossifyOrg/Messages/pull/561
 [#562]: https://github.com/FossifyOrg/Messages/issues/562
+[#574]: https://github.com/FossifyOrg/Messages/issues/574
 
 [Unreleased]: https://github.com/FossifyOrg/Messages/compare/1.5.0...HEAD
 [1.5.0]: https://github.com/FossifyOrg/Messages/compare/1.4.0...1.5.0

--- a/app/src/main/kotlin/org/fossify/messages/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/messages/extensions/Context.kt
@@ -994,15 +994,24 @@ fun Context.markMessageRead(id: Long, isMMS: Boolean) {
 }
 
 fun Context.markThreadMessagesRead(threadId: Long) {
-    arrayOf(Sms.CONTENT_URI, Mms.CONTENT_URI).forEach { uri ->
-        val contentValues = ContentValues().apply {
-            put(Sms.READ, 1)
-            put(Sms.SEEN, 1)
-        }
-        val selection = "${Sms.THREAD_ID} = ?"
-        val selectionArgs = arrayOf(threadId.toString())
-        contentResolver.update(uri, contentValues, selection, selectionArgs)
+    val id = threadId.toString()
+
+    val smsValues = ContentValues().apply {
+        put(Sms.READ, 1)
+        put(Sms.SEEN, 1)
     }
+    val smsSelection = "${Sms.THREAD_ID}=? AND ${Sms.TYPE}=? AND (${Sms.READ}=? OR ${Sms.SEEN}=?)"
+    val smsArgs = arrayOf(id, Sms.MESSAGE_TYPE_INBOX.toString(), "0", "0")
+    contentResolver.update(Sms.CONTENT_URI, smsValues, smsSelection, smsArgs)
+
+    val mmsValues = ContentValues().apply {
+        put(Mms.READ, 1)
+        put(Mms.SEEN, 1)
+    }
+    val mmsSelection = "${Mms.THREAD_ID}=? AND ${Mms.MESSAGE_BOX}=? AND (${Mms.READ}=? OR ${Mms.SEEN}=?)"
+    val mmsArgs = arrayOf(id, Mms.MESSAGE_BOX_INBOX.toString(), "0", "0")
+    contentResolver.update(Mms.CONTENT_URI, mmsValues, mmsSelection, mmsArgs)
+
     messagesDB.markThreadRead(threadId)
     conversationsDB.markRead(threadId)
 }


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Applied proper selection when marking messages as read. This was not a big issue before because users rarely marked long threads as read/unread, but the fix in https://github.com/FossifyOrg/Messages/pull/560 made **Mark as read** unconditional on resume, leading to SQLite pool exhaustion.
- Mark as read should work better now due to this change.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Tested scrolling and sending messages in a thread containing 10,000 fake SMS and MMS messages inserted into the telephony database.
 
#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Messages/issues/574

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
