### PR TITLE
feat: allow copying multiple messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Ability to select and copy multiple text messages at once ([#600])
 
 ## [1.6.0] - 2025-10-29
 ### Changed
@@ -200,6 +202,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#561]: https://github.com/FossifyOrg/Messages/issues/561
 [#562]: https://github.com/FossifyOrg/Messages/issues/562
 [#574]: https://github.com/FossifyOrg/Messages/issues/574
+[#600]: https://github.com/FossifyOrg/Messages/issues/600
 
 [Unreleased]: https://github.com/FossifyOrg/Messages/compare/1.6.0...HEAD
 [1.6.0]: https://github.com/FossifyOrg/Messages/compare/1.5.0...1.6.0


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Updated **Copy to clipboard** visibility condition to allow multiple selections. Messages are separated by two empty lines.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Copying to clipboard

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #600

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
