### PR TITLE
fix: properly handle "New conversation" shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to select and copy multiple text messages at once ([#600])
 
 ### Fixed
-- Fixed new conversation shortcut behaving like in-app ([#416])
+- Fixed new conversation shortcut ([#416])
 
 ## [1.6.0] - 2025-10-29
 ### Changed

--- a/app/src/main/kotlin/org/fossify/messages/activities/NewConversationActivity.kt
+++ b/app/src/main/kotlin/org/fossify/messages/activities/NewConversationActivity.kt
@@ -138,7 +138,7 @@ class NewConversationActivity : SimpleActivity() {
     private fun isThirdPartyIntent(): Boolean {
         val result = SmsIntentParser.parse(intent)
 
-        if (result != null && result.first.isNotEmpty() && result.second.isNotEmpty()) {
+        if (result != null && (result.first.isNotEmpty() || result.second.isNotEmpty())) {
             val (body, recipients) = result
             launchThreadActivity(
                 phoneNumber = URLDecoder.decode(recipients.replace("+", "%2b").trim()),


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [X] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Fixed new conversation shortcut behaving like thirdPartyIntent


#### Before & after preview
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->
Old Behavior:
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/f196b8ac-7264-400b-9edf-06ad65d6e776" width=180 />
New Behavior:
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/10dfb456-1295-4191-bcd6-ddd4dd622b20" width=180 />


#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #416 

#### Checklist
- [X] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [X] I manually tested my changes on device/emulator (if applicable).
- [X] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [X] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [X] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
