### PR TITLE
fix: properly block MMS messages from unknown numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed new conversation shortcut ([#416])
+- Fixed blocking MMS messages from unknown numbers ([#610])
 
 ## [1.6.0] - 2025-10-29
 ### Changed
@@ -207,6 +208,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#562]: https://github.com/FossifyOrg/Messages/issues/562
 [#574]: https://github.com/FossifyOrg/Messages/issues/574
 [#600]: https://github.com/FossifyOrg/Messages/issues/600
+[#610]: https://github.com/FossifyOrg/Messages/issues/610
 
 [Unreleased]: https://github.com/FossifyOrg/Messages/compare/1.6.0...HEAD
 [1.6.0]: https://github.com/FossifyOrg/Messages/compare/1.5.0...1.6.0

--- a/app/src/main/kotlin/org/fossify/messages/receivers/SmsReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/SmsReceiver.kt
@@ -53,6 +53,7 @@ class SmsReceiver : BroadcastReceiver() {
             }
             if (context.baseConfig.blockUnknownNumbers) {
                 val simpleContactsHelper = SimpleContactsHelper(context)
+                // Maybe switch to existsSync()? No?
                 simpleContactsHelper.exists(address, privateCursor) { exists ->
                     if (exists) {
                         handleMessage(context, address, subject, body, date, read, threadId, type, subscriptionId, status)


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->
#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Moved the unknown number check condition to the `isAddressBlocked()` function from mmslib. Without this, MMS messages from unknown numbers were always saved to the telephony database.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - I can't reliably test it.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Messages/issues/610
- Closes https://github.com/FossifyOrg/Messages/issues/189

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
