### PR TITLE
fix: don't block *all* senders due to missing permissions or errors

### DIFF
--- a/app/src/main/kotlin/org/fossify/messages/receivers/SmsReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/SmsReceiver.kt
@@ -7,6 +7,7 @@ import android.provider.Telephony
 import org.fossify.commons.extensions.baseConfig
 import org.fossify.commons.extensions.getMyContactsCursor
 import org.fossify.commons.extensions.isNumberBlocked
+import org.fossify.commons.helpers.ContactLookupResult
 import org.fossify.commons.helpers.SimpleContactsHelper
 import org.fossify.commons.helpers.ensureBackgroundThread
 import org.fossify.commons.models.PhoneNumber
@@ -47,10 +48,10 @@ class SmsReceiver : BroadcastReceiver() {
                 if (isMessageFilteredOut(appContext, body)) return@ensureBackgroundThread
                 if (appContext.isNumberBlocked(address)) return@ensureBackgroundThread
                 if (appContext.baseConfig.blockUnknownNumbers) {
-                    appContext.getMyContactsCursor(favoritesOnly = false, withPhoneNumbersOnly = true).use {
-                        val isKnownContact = SimpleContactsHelper(appContext).existsSync(address, it)
-                        if (!isKnownContact) return@ensureBackgroundThread
-                    }
+                    val privateCursor =
+                        appContext.getMyContactsCursor(favoritesOnly = false, withPhoneNumbersOnly = true)
+                    val result = SimpleContactsHelper(appContext).existsSync(address, privateCursor)
+                    if (result == ContactLookupResult.NotFound) return@ensureBackgroundThread
                 }
 
                 val date = System.currentTimeMillis()


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
 - Updated `SmsReceiver` and `MmsReceiver` to not block all senders when contact lookup results are unclear. More info in https://github.com/FossifyOrg/commons/pull/289.
 - Fixed a bug where blocking messages from unknown numbers wouldn't work if private contacts are not accessible. This was caused by a previous change and is not live in the latest release.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - [x] SMS messages from unknown senders are blocked when unknown number blocking is enabled. 
 - [x] SMS messages from all senders are **not** blocked when contact permission is denied. 
 
Can't test MMS.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

- Not tracked. Edge case bug.

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable) - No because changelog will hit 500 char limit. 
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
