### PR TITLE
feat: show notification action to copy OTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Copy OTP from notification ([#275])
 
 ## [1.8.0] - 2026-01-30
 ### Added

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -240,6 +240,15 @@
         </receiver>
 
         <receiver
+            android:name=".receivers.CopyCodeReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="org.fossify.messages.action.copy_code" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
             android:name=".receivers.ScheduledMessageReceiver"
             android:exported="false" />
 

--- a/app/src/main/kotlin/org/fossify/messages/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/Constants.kt
@@ -52,6 +52,8 @@ const val KEEP_CONVERSATIONS_ARCHIVED = "keep_conversations_archived"
 private const val PATH = "org.fossify.org.fossify.messages.action."
 const val MARK_AS_READ = PATH + "mark_as_read"
 const val REPLY = PATH + "reply"
+const val COPY_CODE = PATH + "copy_code"
+const val CODE_TO_COPY = "code_to_copy"
 
 // view types for the thread list view
 const val THREAD_DATE_TIME = 1

--- a/app/src/main/kotlin/org/fossify/messages/helpers/NotificationHelper.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/NotificationHelper.kt
@@ -23,6 +23,7 @@ import org.fossify.messages.activities.ThreadActivity
 import org.fossify.messages.extensions.config
 import org.fossify.messages.extensions.shortcutHelper
 import org.fossify.messages.messaging.isShortCodeWithLetters
+import org.fossify.messages.receivers.CopyCodeReceiver
 import org.fossify.messages.receivers.DeleteSmsReceiver
 import org.fossify.messages.receivers.DirectReplyReceiver
 import org.fossify.messages.receivers.MarkAsReadReceiver
@@ -118,6 +119,26 @@ class NotificationHelper(private val context: Context) {
                 .build()
         }
 
+        val verificationCode = extractVerificationCode(body)
+        var copyCodeAction: NotificationCompat.Action? = null
+        if (verificationCode != null) {
+            val copyCodeIntent = Intent(context, CopyCodeReceiver::class.java).apply {
+                action = COPY_CODE
+                putExtra(CODE_TO_COPY, verificationCode)
+            }
+            val copyCodePendingIntent = PendingIntent.getBroadcast(
+                context,
+                notificationId,
+                copyCodeIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            )
+            copyCodeAction = NotificationCompat.Action.Builder(
+                org.fossify.commons.R.drawable.ic_copy_vector,
+                verificationCode,
+                copyCodePendingIntent
+            ).build()
+        }
+
         val largeIcon = bitmap ?: if (sender != null) {
             SimpleContactsHelper(context).getContactLetterIcon(sender)
         } else {
@@ -153,6 +174,10 @@ class NotificationHelper(private val context: Context) {
 
         if (replyAction != null && context.config.lockScreenVisibilitySetting == LOCK_SCREEN_SENDER_MESSAGE) {
             builder.addAction(replyAction)
+        }
+
+        if (copyCodeAction != null) {
+            builder.addAction(copyCodeAction)
         }
 
         builder.addAction(
@@ -281,5 +306,10 @@ class NotificationHelper(private val context: Context) {
         } else {
             emptyList()
         }
+    }
+
+    private fun extractVerificationCode(body: String): String? {
+        val verificationCodePattern = Regex("""\b(\d{4,8})\b""")
+        return verificationCodePattern.find(body)?.groupValues?.get(1)
     }
 }

--- a/app/src/main/kotlin/org/fossify/messages/receivers/CopyCodeReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/CopyCodeReceiver.kt
@@ -1,0 +1,16 @@
+package org.fossify.messages.receivers
+
+import android.content.BroadcastReceiver
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import org.fossify.messages.helpers.CODE_TO_COPY
+
+class CopyCodeReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val code = intent.getStringExtra(CODE_TO_COPY) ?: return
+        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        clipboard.setPrimaryClip(ClipData.newPlainText("code", code))
+    }
+}


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
Added notification option on message to copy short numeric code e.g. OTP

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Tested manually with 6 digit code from telecommunication provider with OnePlus phone

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

- Closes #275 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
