### PR TITLE
Handle missing contacts provider gracefully when loading avatars

### DIFF
--- a/app/src/main/kotlin/org/fossify/messages/adapters/BaseConversationsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/messages/adapters/BaseConversationsAdapter.kt
@@ -1,6 +1,7 @@
 package org.fossify.messages.adapters
 
 import android.annotation.SuppressLint
+import android.graphics.drawable.BitmapDrawable
 import android.graphics.Typeface
 import android.os.Parcelable
 import android.util.TypedValue
@@ -25,6 +26,7 @@ import org.fossify.commons.views.MyRecyclerView
 import org.fossify.messages.activities.SimpleActivity
 import org.fossify.messages.databinding.ItemConversationBinding
 import org.fossify.messages.extensions.config
+import org.fossify.messages.extensions.canResolveImagePath
 import org.fossify.messages.extensions.getAllDrafts
 import org.fossify.messages.models.Conversation
 
@@ -192,19 +194,45 @@ abstract class BaseConversationsAdapter(
             }
 
             setupBadgeCount(unreadCountBadge, isUnread, conversation.unreadCount)
-            // at group conversations we use an icon as the placeholder, not any letter
-            val placeholder = if (conversation.isGroupConversation) {
-                SimpleContactsHelper(activity).getColoredGroupIcon(conversation.title)
-            } else {
-                null
-            }
 
-            SimpleContactsHelper(activity).loadContactImage(
-                path = conversation.photoUri,
-                imageView = conversationImage,
-                placeholderName = conversation.title,
-                placeholderImage = placeholder
-            )
+	    // at group conversations we use an icon as the placeholder, not any letter
+
+	    //val placeholder = if (conversation.isGroupConversation) {
+            //    SimpleContactsHelper(activity).getColoredGroupIcon(conversation.title)
+            //} else {
+            //    null
+            //}
+	    //
+            //SimpleContactsHelper(activity).loadContactImage(
+            //    path = conversation.photoUri,
+            //    imageView = conversationImage,
+            //    placeholderName = conversation.title,
+            //    placeholderImage = placeholder
+            //)
+	    
+	    // attempt to gracefully fall back to placeholder when contactsprovider is not available
+
+	    val contactsHelper = SimpleContactsHelper(activity)
+	    val placeholder = if (conversation.isGroupConversation) {
+	        contactsHelper.getColoredGroupIcon(conversation.title)
+	    } else {
+	        null
+	    }
+
+	    if (activity.canResolveImagePath(conversation.photoUri)) {
+	        contactsHelper.loadContactImage(
+	            path = conversation.photoUri,
+	            imageView = conversationImage,
+	            placeholderName = conversation.title,
+	            placeholderImage = placeholder
+	        )
+	    } else {
+	        val fallback = placeholder ?: BitmapDrawable(
+	            activity.resources,
+	            contactsHelper.getContactLetterIcon(conversation.title)
+	        )
+	        conversationImage.setImageDrawable(fallback)
+	    }
         }
     }
 

--- a/app/src/main/kotlin/org/fossify/messages/adapters/ThreadAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/messages/adapters/ThreadAdapter.kt
@@ -62,6 +62,7 @@ import org.fossify.messages.databinding.ItemThreadSuccessBinding
 import org.fossify.messages.dialogs.DeleteConfirmationDialog
 import org.fossify.messages.dialogs.MessageDetailsDialog
 import org.fossify.messages.dialogs.SelectTextDialog
+import org.fossify.messages.extensions.canResolveImagePath
 import org.fossify.messages.extensions.config
 import org.fossify.messages.extensions.getContactFromAddress
 import org.fossify.messages.extensions.isImageMimeType
@@ -440,12 +441,26 @@ class ThreadAdapter(
                     .error(placeholder)
                     .centerCrop()
 
-                Glide.with(activity)
-                    .load(message.senderPhotoUri)
-                    .placeholder(placeholder)
-                    .apply(options)
-                    .apply(RequestOptions.circleCropTransform())
-                    .into(threadMessageSenderPhoto)
+		// testing graceful fallback    
+
+		//Glide.with(activity)
+                //    .load(message.senderPhotoUri)
+                //    .placeholder(placeholder)
+                //    .apply(options)
+                //    .apply(RequestOptions.circleCropTransform())
+                //    .into(threadMessageSenderPhoto)
+
+		if (activity.canResolveImagePath(message.senderPhotoUri)) {
+		    Glide.with(activity)
+		        .load(message.senderPhotoUri)
+			.placeholder(placeholder)
+			.apply(options)
+			.apply(RequestOptions.circleCropTransform())
+			.into(threadMessageSenderPhoto)
+		} else {
+		    Glide.with(activity).clear(threadMessageSenderPhoto)
+		    threadMessageSenderPhoto.setImageDrawable(placeholder)
+		}
             }
         }
     }

--- a/app/src/main/kotlin/org/fossify/messages/extensions/ImagePathExtensions.kt
+++ b/app/src/main/kotlin/org/fossify/messages/extensions/ImagePathExtensions.kt
@@ -1,0 +1,19 @@
+package org.fossify.messages.extensions
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+
+fun Context.canResolveImagePath(path: String?): Boolean {
+    if (path.isNullOrBlank()) {
+        return false
+    }
+
+    val uri = Uri.parse(path)
+    if (uri.scheme != ContentResolver.SCHEME_CONTENT) {
+        return true
+    }
+
+    val authority = uri.authority ?: return false
+    return packageManager.resolveContentProvider(authority, 0) != null
+}


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ o ] Bug fix

#### What changed and why
App is throwing these errors:

`Failed to find provider info for org.fossify.commons.contactsprovider`

Right when that happens, Fossify also starts spamming Glide image-load failures in the same area of the log, which looks like contact/avatar loading is failing while the thread view opens.

The contacts provider authority does not seem to be registered in the app, so we should gracefully handle when it is not.

#### Tests performed
Built and installed onto S25 Ultra:

One UI: v8.0
Android: v16


#### Closes the following issue(s)
Does not address reported issues. Was hopeful this would resolve issues/204, but the java exception popup still happens. Will continue to debug and provide further code changes if possible to continue chasing that issue.

- Closes #

#### Checklist
- [ o ] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ o ] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ o ] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [ o ] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->