### PR TITLE
fix: invalidate stale thread participants when recipients change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed messages being sent to the wrong contact ([#615])
 
 ## [1.8.0] - 2026-01-30
 ### Added
@@ -235,6 +237,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#574]: https://github.com/FossifyOrg/Messages/issues/574
 [#600]: https://github.com/FossifyOrg/Messages/issues/600
 [#610]: https://github.com/FossifyOrg/Messages/issues/610
+[#615]: https://github.com/FossifyOrg/Messages/issues/615
 [#641]: https://github.com/FossifyOrg/Messages/issues/641
 [#644]: https://github.com/FossifyOrg/Messages/issues/644
 [#651]: https://github.com/FossifyOrg/Messages/issues/651

--- a/app/src/main/kotlin/org/fossify/messages/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/org/fossify/messages/activities/ThreadActivity.kt
@@ -492,12 +492,13 @@ class ThreadActivity : SimpleActivity() {
                 }
             }
 
+            val providerParticipantsChanged = reconcileProviderParticipants()
             val hasParticipantWithoutName = participants.any { contact ->
                 contact.phoneNumbers.map { it.normalizedNumber }.contains(contact.name)
             }
 
             try {
-                if (participants.isNotEmpty() && messages.hashCode() == cachedMessagesCode && !hasParticipantWithoutName) {
+                if (canReuseLoadedThread(providerParticipantsChanged, cachedMessagesCode, hasParticipantWithoutName)) {
                     setupAdapter()
                     runOnUiThread { callback() }
                     return@ensureBackgroundThread
@@ -562,6 +563,18 @@ class ThreadActivity : SimpleActivity() {
                 callback()
             }
         }
+    }
+
+    private fun canReuseLoadedThread(
+        providerParticipantsChanged: Boolean,
+        cachedMessagesCode: Int,
+        hasParticipantWithoutName: Boolean,
+    ): Boolean {
+        if (providerParticipantsChanged || participants.isEmpty() || hasParticipantWithoutName) {
+            return false
+        }
+
+        return messages.hashCode() == cachedMessagesCode
     }
 
     private fun getOrCreateThreadAdapter(): ThreadAdapter {
@@ -962,9 +975,35 @@ class ThreadActivity : SimpleActivity() {
         }
     }
 
+    private fun hasOnlyScheduledMessages(): Boolean {
+        return messages.isNotEmpty() && messages.all { it.isScheduled }
+    }
+
+    private fun getProviderThreadParticipants(): ArrayList<SimpleContact>? {
+        if (isRecycleBin || threadId <= 0L || hasOnlyScheduledMessages()) {
+            return null
+        }
+
+        return getThreadParticipants(threadId, null).takeIf { it.isNotEmpty() }
+    }
+
+    private fun reconcileProviderParticipants(): Boolean {
+        val providerParticipants = getProviderThreadParticipants() ?: return false
+        val participantsChanged = participants.getAddresses() != providerParticipants.getAddresses()
+        participants = providerParticipants
+
+        if (participantsChanged) {
+            runOnUiThread {
+                maybeDisableShortCodeReply()
+            }
+        }
+
+        return participantsChanged
+    }
+
     private fun setupParticipants() {
         if (participants.isEmpty()) {
-            participants = if (messages.isEmpty()) {
+            participants = getProviderThreadParticipants() ?: if (messages.isEmpty()) {
                 val intentNumbers = getPhoneNumbersFromIntent()
                 val participants = getThreadParticipants(threadId, null)
                 fixParticipantNumbers(participants, intentNumbers)
@@ -1778,6 +1817,7 @@ class ThreadActivity : SimpleActivity() {
         }
 
         val lastMaxId = messages.filterNot { it.isScheduled }.maxByOrNull { it.id }?.id ?: 0L
+        val providerParticipantsChanged = reconcileProviderParticipants()
         val newThreadId = getThreadId(participants.getAddresses().toSet())
         val newMessages = getMessages(newThreadId, includeScheduledMessages = false)
         if (messages.isNotEmpty() && messages.all { it.isScheduled } && newMessages.isNotEmpty()) {
@@ -1806,6 +1846,9 @@ class ThreadActivity : SimpleActivity() {
 
         setupAdapter()
         runOnUiThread {
+            if (providerParticipantsChanged) {
+                setupThreadTitle()
+            }
             setupSIMSelector()
         }
     }

--- a/app/src/main/kotlin/org/fossify/messages/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/org/fossify/messages/activities/ThreadActivity.kt
@@ -1003,12 +1003,12 @@ class ThreadActivity : SimpleActivity() {
 
     private fun setupParticipants() {
         if (participants.isEmpty()) {
-            participants = getProviderThreadParticipants() ?: if (messages.isEmpty()) {
+            participants = if (messages.isEmpty()) {
                 val intentNumbers = getPhoneNumbersFromIntent()
                 val participants = getThreadParticipants(threadId, null)
                 fixParticipantNumbers(participants, intentNumbers)
             } else {
-                messages.first().participants
+                getProviderThreadParticipants() ?: messages.first().participants
             }
             runOnUiThread {
                 maybeDisableShortCodeReply()

--- a/app/src/main/kotlin/org/fossify/messages/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/messages/extensions/Context.kt
@@ -616,59 +616,65 @@ fun Context.getThreadParticipants(
     threadId: Long,
     contactsMap: HashMap<Int, SimpleContact>?,
 ): ArrayList<SimpleContact> {
-    MessagingCache.participantsCache.get(threadId)?.let {
-        return it.map { contact ->
-            contact.copy(
-                phoneNumbers = contact.phoneNumbers.toArrayList(),
-                birthdays = contact.birthdays.toArrayList(),
-                anniversaries = contact.anniversaries.toArrayList()
-            )
-        }.toArrayList()
+    val recipientIds = getThreadRecipientIds(threadId)
+    val phoneNumbers = getThreadPhoneNumbers(recipientIds)
+    MessagingCache.participantsCache.get(threadId, phoneNumbers)?.let {
+        return it
     }
 
-    val uri = "${MmsSms.CONTENT_CONVERSATIONS_URI}?simple=true".toUri()
-    val projection = arrayOf(
-        ThreadsColumns.RECIPIENT_IDS
-    )
-    val selection = "${Mms._ID} = ?"
-    val selectionArgs = arrayOf(threadId.toString())
     val participants = ArrayList<SimpleContact>()
-    try {
-        val cursor = contentResolver.query(uri, projection, selection, selectionArgs, null)
-        cursor?.use {
-            if (cursor.moveToFirst()) {
-                val address = cursor.getStringValue(ThreadsColumns.RECIPIENT_IDS)
-                address.split(" ").filter { it.areDigitsOnly() }.forEach {
-                    val addressId = it.toInt()
-                    if (contactsMap?.containsKey(addressId) == true) {
-                        participants.add(contactsMap[addressId]!!)
-                        return@forEach
-                    }
-
-                    val number = getPhoneNumberFromAddressId(addressId)
-                    val namePhoto = getNameAndPhotoFromPhoneNumber(number)
-                    val name = namePhoto.name
-                    val photoUri = namePhoto.photoUri ?: ""
-                    val phoneNumber = PhoneNumber(number, 0, "", number)
-                    val contact = SimpleContact(
-                        rawId = addressId,
-                        contactId = addressId,
-                        name = name,
-                        photoUri = photoUri,
-                        phoneNumbers = arrayListOf(phoneNumber),
-                        birthdays = ArrayList(),
-                        anniversaries = ArrayList()
-                    )
-                    participants.add(contact)
-                }
-            }
+    recipientIds.zip(phoneNumbers).forEach { (addressId, number) ->
+        val cachedContact = contactsMap?.get(addressId)
+        val threadPhoneNumber = cachedContact
+            ?.phoneNumbers
+            ?.firstOrNull { it.normalizedNumber == number }
+        if (cachedContact != null && threadPhoneNumber != null) {
+            participants.add(
+                cachedContact.copy(
+                    phoneNumbers = arrayListOf(threadPhoneNumber.copy()),
+                    birthdays = ArrayList(cachedContact.birthdays),
+                    anniversaries = ArrayList(cachedContact.anniversaries)
+                )
+            )
+            return@forEach
         }
-    } catch (e: Exception) {
-        showErrorToast(e)
+
+        val namePhoto = getNameAndPhotoFromPhoneNumber(number)
+        val name = namePhoto.name
+        val photoUri = namePhoto.photoUri ?: ""
+        val phoneNumber = PhoneNumber(number, 0, "", number)
+        val contact = SimpleContact(
+            rawId = addressId,
+            contactId = addressId,
+            name = name,
+            photoUri = photoUri,
+            phoneNumbers = arrayListOf(phoneNumber),
+            birthdays = ArrayList(),
+            anniversaries = ArrayList()
+        )
+        participants.add(contact)
     }
 
-    MessagingCache.participantsCache.put(threadId, participants)
+    MessagingCache.participantsCache.put(threadId, phoneNumbers, participants)
     return participants
+}
+
+private fun Context.getThreadRecipientIds(threadId: Long): List<Int> {
+    val recipientIds = ArrayList<Int>()
+    queryCursor(
+        uri = "${MmsSms.CONTENT_CONVERSATIONS_URI}?simple=true".toUri(),
+        projection = arrayOf(ThreadsColumns.RECIPIENT_IDS),
+        selection = "${Mms._ID} = ?",
+        selectionArgs = arrayOf(threadId.toString()),
+        showErrors = true
+    ) { cursor ->
+        cursor.getStringValue(ThreadsColumns.RECIPIENT_IDS)
+            .split(" ")
+            .filter { it.areDigitsOnly() }
+            .forEach { recipientIds.add(it.toInt()) }
+    }
+
+    return recipientIds
 }
 
 fun Context.getThreadPhoneNumbers(recipientIds: List<Int>): ArrayList<String> {

--- a/app/src/main/kotlin/org/fossify/messages/helpers/MessagingCache.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/MessagingCache.kt
@@ -8,5 +8,71 @@ private const val CACHE_SIZE = 512
 
 object MessagingCache {
     val namePhoto = LruCache<String, NamePhoto>(CACHE_SIZE)
-    val participantsCache = LruCache<Long, ArrayList<SimpleContact>>(CACHE_SIZE)
+    internal val participantsCache = ThreadParticipantsCache(CACHE_SIZE)
+}
+
+internal class ThreadParticipantsCache(private val maxSize: Int) {
+    private val lock = Any()
+    private val entries = LruCache<Long, Entry>(maxSize)
+
+    fun get(threadId: Long, recipientNumbers: List<String>): ArrayList<SimpleContact>? {
+        val key = recipientNumbers.toRecipientCacheKey()
+        synchronized(lock) {
+            val entry = entries.get(threadId) ?: return null
+            if (entry.recipientNumbers != key) {
+                entries.remove(threadId)
+                return null
+            }
+
+            return entry.participants.deepCopy()
+        }
+    }
+
+    fun put(
+        threadId: Long,
+        recipientNumbers: List<String>,
+        participants: ArrayList<SimpleContact>,
+    ) {
+        if (participants.isEmpty()) return
+        synchronized(lock) {
+            entries.put(
+                threadId,
+                Entry(
+                    recipientNumbers = recipientNumbers.toRecipientCacheKey(),
+                    participants = participants.deepCopy()
+                )
+            )
+        }
+    }
+
+    fun remove(threadId: Long) {
+        synchronized(lock) {
+            entries.remove(threadId)
+        }
+    }
+
+    fun evictAll() {
+        synchronized(lock) {
+            entries.evictAll()
+        }
+    }
+
+    private data class Entry(
+        val recipientNumbers: List<String>,
+        val participants: ArrayList<SimpleContact>,
+    )
+}
+
+private fun List<String>.toRecipientCacheKey(): List<String> {
+    return map { it.trim() }
+}
+
+private fun ArrayList<SimpleContact>.deepCopy(): ArrayList<SimpleContact> {
+    return map { contact ->
+        contact.copy(
+            phoneNumbers = ArrayList(contact.phoneNumbers),
+            birthdays = ArrayList(contact.birthdays),
+            anniversaries = ArrayList(contact.anniversaries)
+        )
+    }.toCollection(ArrayList())
 }


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Fix stale thread participant cache when a thread's recipient identity changes.
- Refresh conversation participants from when opening or refreshing a thread.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - I could never reproduce the original bug, but I have tested sending SMS messages to various contacts and normal app operation.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

- Closes https://github.com/FossifyOrg/Messages/issues/615
- Maybe https://github.com/FossifyOrg/Messages/issues/595
- Maybe https://github.com/FossifyOrg/Messages/issues/365

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
