### PR TITLE
fix: handle message crash edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed messages being sent to the wrong contact ([#615])
 - Fixed incomplete message exports ([#713])
 - Fixed crash when viewing older messages
+- Other stability improvements
 
 ## [1.8.0] - 2026-01-30
 ### Added

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -33,3 +33,14 @@
 -keep class org.fossify.commons.models.SimpleContact { *; }
 -keep class org.fossify.messages.models.Attachment { *; }
 -keep class org.fossify.messages.models.MessageAttachment { *; }
+
+# ez-vcard's parameter registries use reflection to enumerate public constants
+# and create runtime values for unknown TYPE/MEDIATYPE parameters.
+-keepclassmembers,allowobfuscation class ezvcard.parameter.* extends ezvcard.parameter.VCardParameter {
+    public static final <fields>;
+    <init>(java.lang.String);
+}
+
+-keepclassmembers,allowobfuscation class ezvcard.parameter.* extends ezvcard.parameter.MediaTypeParameter {
+    <init>(java.lang.String, java.lang.String, java.lang.String);
+}

--- a/app/src/main/kotlin/org/fossify/messages/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/messages/adapters/ConversationsAdapter.kt
@@ -64,7 +64,8 @@ class ConversationsAdapter(
     }
 
     override fun actionItemPressed(id: Int) {
-        if (selectedKeys.isEmpty()) {
+        val selectedItems = getSelectedItems()
+        if (selectedItems.isEmpty()) {
             return
         }
 
@@ -75,9 +76,9 @@ class ConversationsAdapter(
             R.id.cab_copy_number -> copyNumberToClipboard()
             R.id.cab_delete -> askConfirmDelete()
             R.id.cab_archive -> askConfirmArchive()
-            R.id.cab_rename_conversation -> renameConversation(getSelectedItems().first())
+            R.id.cab_rename_conversation -> renameConversation(selectedItems.first())
             R.id.cab_conversation_details ->
-                activity.launchConversationDetails(getSelectedItems().first().threadId)
+                activity.launchConversationDetails(selectedItems.first().threadId)
 
             R.id.cab_mark_as_read -> markAsRead()
             R.id.cab_mark_as_unread -> markAsUnread()

--- a/app/src/main/kotlin/org/fossify/messages/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/messages/extensions/Context.kt
@@ -220,8 +220,8 @@ fun Context.getMMS(
     threadId: Long? = null,
     sortOrder: String? = null,
     dateFrom: Int = -1,
+    uri: Uri = Mms.CONTENT_URI,
 ): ArrayList<Message> {
-    val uri = Mms.CONTENT_URI
     val projection = arrayOf(
         Mms._ID,
         Mms.DATE,
@@ -563,6 +563,10 @@ fun Context.getMmsAttachment(id: Long): MessageAttachment {
 fun Context.getLatestMMS(): Message? {
     val sortOrder = "${Mms.DATE} DESC LIMIT 1"
     return getMMS(sortOrder = sortOrder).firstOrNull()
+}
+
+fun Context.getMMS(messageUri: Uri): Message? {
+    return getMMS(uri = messageUri).firstOrNull()
 }
 
 fun Context.getThreadSnippet(threadId: Long): String {

--- a/app/src/main/kotlin/org/fossify/messages/helpers/VCardParser.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/VCardParser.kt
@@ -4,19 +4,60 @@ import android.content.Context
 import android.net.Uri
 import ezvcard.Ezvcard
 import ezvcard.VCard
+import ezvcard.io.scribe.LogoScribe
+import ezvcard.io.scribe.PhotoScribe
+import ezvcard.parameter.ImageType
 import org.fossify.commons.helpers.ensureBackgroundThread
 
 fun parseVCardFromUri(context: Context, uri: Uri, callback: (vCards: List<VCard>) -> Unit) {
     ensureBackgroundThread {
-        val inputStream = try {
-            context.contentResolver.openInputStream(uri)
+        val vCards = try {
+            context.contentResolver.openInputStream(uri)?.use { inputStream ->
+                Ezvcard.parse(inputStream)
+                    .register(LenientPhotoScribe())
+                    .register(LenientLogoScribe())
+                    .all()
+            } ?: emptyList()
         } catch (e: Exception) {
-            callback(emptyList())
-            return@ensureBackgroundThread
+            emptyList()
         }
-        val vCards = Ezvcard.parse(inputStream).all()
+
         callback(vCards)
     }
+}
+
+private class LenientPhotoScribe : PhotoScribe() {
+    override fun _mediaTypeFromTypeParameter(type: String?): ImageType? =
+        findImageType(type = type)
+
+    override fun _mediaTypeFromMediaTypeParameter(mediaType: String?): ImageType? =
+        findImageType(mediaType = mediaType)
+
+    override fun _mediaTypeFromFileExtension(extension: String?): ImageType? =
+        findImageType(extension = extension)
+}
+
+private class LenientLogoScribe : LogoScribe() {
+    override fun _mediaTypeFromTypeParameter(type: String?): ImageType? =
+        findImageType(type = type)
+
+    override fun _mediaTypeFromMediaTypeParameter(mediaType: String?): ImageType? =
+        findImageType(mediaType = mediaType)
+
+    override fun _mediaTypeFromFileExtension(extension: String?): ImageType? =
+        findImageType(extension = extension)
+}
+
+private fun findImageType(
+    type: String? = null,
+    mediaType: String? = null,
+    extension: String? = null,
+): ImageType? {
+    if (type == null && mediaType == null && extension == null) {
+        return null
+    }
+
+    return ImageType.find(type, mediaType, extension)
 }
 
 fun VCard?.parseNameFromVCard(): String? {

--- a/app/src/main/kotlin/org/fossify/messages/receivers/MmsReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/MmsReceiver.kt
@@ -13,6 +13,7 @@ import org.fossify.commons.helpers.SimpleContactsHelper
 import org.fossify.commons.helpers.ensureBackgroundThread
 import org.fossify.messages.R
 import org.fossify.messages.extensions.getConversations
+import org.fossify.messages.extensions.getMMS
 import org.fossify.messages.extensions.getLatestMMS
 import org.fossify.messages.extensions.getNameFromAddress
 import org.fossify.messages.extensions.insertOrUpdateConversation
@@ -41,9 +42,9 @@ class MmsReceiver : MmsReceivedReceiver() {
         return isMessageFilteredOut(context, content)
     }
 
-    override fun onMessageReceived(context: Context, messageUri: Uri) {
-        val mms = context.getLatestMMS() ?: return
-        val address = mms.getSender()?.phoneNumbers?.firstOrNull()?.normalizedNumber ?: ""
+    override fun onMessageReceived(context: Context, messageUri: Uri?) {
+        val mms = messageUri?.let { context.getMMS(it) } ?: context.getLatestMMS() ?: return
+        val address = mms.getSender()?.phoneNumbers?.firstOrNull()?.normalizedNumber ?: mms.senderPhoneNumber
         val size = context.resources.getDimension(R.dimen.notification_large_icon_size).toInt()
         ensureBackgroundThread {
             handleMmsMessage(context, mms, size, address)

--- a/app/src/main/kotlin/org/fossify/messages/receivers/MmsReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/MmsReceiver.kt
@@ -43,7 +43,12 @@ class MmsReceiver : MmsReceivedReceiver() {
     }
 
     override fun onMessageReceived(context: Context, messageUri: Uri?) {
-        val mms = messageUri?.let { context.getMMS(it) } ?: context.getLatestMMS() ?: return
+        val mms = if (messageUri != null) {
+            context.getMMS(messageUri)
+        } else {
+            context.getLatestMMS()
+        } ?: return
+
         val address = mms.getSender()?.phoneNumbers?.firstOrNull()?.normalizedNumber ?: mms.senderPhoneNumber
         val size = context.resources.getDimension(R.dimen.notification_large_icon_size).toInt()
         ensureBackgroundThread {


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Leniently handle malformed vCard PHOTO/LOGO image types instead of crashing
- Preserve recoverable MMS messages by resolving exact MMS URIs
- Handle nullable MMS receiver URIs and fall back to sender data
- Avoid crashes when conversation actions run with an empty/stale selection

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - [x] Sent and received SMS messages
 - [x] Vcard preview tests
 - [x] Conversation selection and deletion
 - [ ] Send and receive group MMS

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

- Mostly untracked crash fixes

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
