### PR TITLE
fix: reduce default mms image limit to 200kb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Partially fixed issue with sending MMS images ([#45])
 
 ## [1.8.1] - 2026-07-09
 ### Changed
@@ -206,6 +208,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 
 [#13]: https://github.com/FossifyOrg/Messages/issues/13
+[#45]: https://github.com/FossifyOrg/Messages/issues/45
 [#70]: https://github.com/FossifyOrg/Messages/issues/70
 [#75]: https://github.com/FossifyOrg/Messages/issues/75
 [#82]: https://github.com/FossifyOrg/Messages/issues/82

--- a/app/src/main/kotlin/org/fossify/messages/helpers/Config.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/Config.kt
@@ -51,7 +51,7 @@ class Config(context: Context) : BaseConfig(context) {
             .putInt(LOCK_SCREEN_VISIBILITY, lockScreenVisibilitySetting).apply()
 
     var mmsFileSizeLimit: Long
-        get() = prefs.getLong(MMS_FILE_SIZE_LIMIT, FILE_SIZE_600_KB)
+        get() = prefs.getLong(MMS_FILE_SIZE_LIMIT, FILE_SIZE_200_KB)
         set(mmsFileSizeLimit) = prefs.edit().putLong(MMS_FILE_SIZE_LIMIT, mmsFileSizeLimit).apply()
 
     var pinnedConversations: Set<String>


### PR DESCRIPTION
This temporarily resolves the issue new users. A proper fix will be done soon so large images can be sent when possible.

Refs: https://github.com/FossifyOrg/Messages/issues/45
