### PR TITLE
feat: ask for group message format choice on first send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added a group message format choice on the first group send ([#52])
+
 ### Fixed
 - Partially fixed issue with sending MMS images ([#45])
 
@@ -209,6 +212,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#13]: https://github.com/FossifyOrg/Messages/issues/13
 [#45]: https://github.com/FossifyOrg/Messages/issues/45
+[#52]: https://github.com/FossifyOrg/Messages/issues/52
 [#70]: https://github.com/FossifyOrg/Messages/issues/70
 [#75]: https://github.com/FossifyOrg/Messages/issues/75
 [#82]: https://github.com/FossifyOrg/Messages/issues/82

--- a/app/src/main/kotlin/org/fossify/messages/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/org/fossify/messages/activities/ThreadActivity.kt
@@ -111,6 +111,7 @@ import org.fossify.messages.adapters.AutoCompleteTextViewAdapter
 import org.fossify.messages.adapters.ThreadAdapter
 import org.fossify.messages.databinding.ActivityThreadBinding
 import org.fossify.messages.databinding.ItemSelectedContactBinding
+import org.fossify.messages.dialogs.GroupMessageSendDialog
 import org.fossify.messages.dialogs.InvalidNumberDialog
 import org.fossify.messages.dialogs.RenameConversationDialog
 import org.fossify.messages.dialogs.ScheduleMessageDialog
@@ -224,6 +225,7 @@ class ThreadActivity : SimpleActivity() {
     private var isLaunchedFromShortcut = false
 
     private var isScheduledMessage: Boolean = false
+    private var isGroupMessageConfirmationVisible = false
     private var messageToResend: Long? = null
     private var scheduledMessage: Message? = null
     private lateinit var scheduledDateTime: DateTime
@@ -1598,15 +1600,41 @@ class ThreadActivity : SimpleActivity() {
 
         if (isScheduledMessage) {
             sendScheduledMessage(text, subscriptionId)
-        } else {
+        } else if (!confirmGroupMessageSendIfNeeded()) {
             sendNormalMessage(text, subscriptionId)
         }
+    }
+
+    private fun confirmGroupMessageSendIfNeeded(): Boolean {
+        if (config.isGroupMessageMmsPreferenceResolved ||
+            participants.getAddresses().distinct().size < 2
+        ) {
+            return false
+        }
+        if (isGroupMessageConfirmationVisible) {
+            return true
+        }
+
+        isGroupMessageConfirmationVisible = true
+        GroupMessageSendDialog(
+            activity = this,
+            callback = { sendAsGroupMms ->
+                config.sendGroupMessageMMS = sendAsGroupMms
+                sendMessage()
+            },
+            onDismiss = { isGroupMessageConfirmationVisible = false }
+        )
+        return true
     }
 
     private fun sendScheduledMessage(text: String, subscriptionId: Int) {
         if (scheduledDateTime.millis < System.currentTimeMillis() + 1000L) {
             toast(R.string.must_pick_time_in_the_future)
             launchScheduleSendDialog(scheduledDateTime)
+            return
+        }
+
+        if (confirmGroupMessageSendIfNeeded()) {
             return
         }
 

--- a/app/src/main/kotlin/org/fossify/messages/dialogs/GroupMessageSendDialog.kt
+++ b/app/src/main/kotlin/org/fossify/messages/dialogs/GroupMessageSendDialog.kt
@@ -1,0 +1,34 @@
+package org.fossify.messages.dialogs
+
+import android.app.Activity
+import org.fossify.commons.extensions.getAlertDialogBuilder
+import org.fossify.commons.extensions.setupDialogStuff
+import org.fossify.messages.R
+import org.fossify.messages.databinding.DialogGroupMessageSendBinding
+
+class GroupMessageSendDialog(
+    activity: Activity,
+    callback: (sendAsGroupMms: Boolean) -> Unit,
+    onDismiss: () -> Unit
+) {
+    init {
+        var selectedChoice: Boolean? = null
+        val binding = DialogGroupMessageSendBinding.inflate(activity.layoutInflater)
+        activity.getAlertDialogBuilder()
+            .setPositiveButton(R.string.group_mms) { _, _ -> selectedChoice = true }
+            .setNegativeButton(R.string.separate_messages) { _, _ -> selectedChoice = false }
+            .apply {
+                activity.setupDialogStuff(
+                    view = binding.root,
+                    dialog = this,
+                    titleId = R.string.send_group_message
+                ) { dialog ->
+                    dialog.setOnDismissListener {
+                        val choice = selectedChoice
+                        onDismiss()
+                        choice?.let(callback)
+                    }
+                }
+            }
+    }
+}

--- a/app/src/main/kotlin/org/fossify/messages/helpers/Config.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/Config.kt
@@ -45,6 +45,9 @@ class Config(context: Context) : BaseConfig(context) {
         set(sendGroupMessageMMS) = prefs.edit()
             .putBoolean(SEND_GROUP_MESSAGE_MMS, sendGroupMessageMMS).apply()
 
+    val isGroupMessageMmsPreferenceResolved: Boolean
+        get() = prefs.contains(SEND_GROUP_MESSAGE_MMS)
+
     var lockScreenVisibilitySetting: Int
         get() = prefs.getInt(LOCK_SCREEN_VISIBILITY, LOCK_SCREEN_SENDER_MESSAGE)
         set(lockScreenVisibilitySetting) = prefs.edit()

--- a/app/src/main/res/layout/dialog_group_message_send.xml
+++ b/app/src/main/res/layout/dialog_group_message_send.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.fossify.commons.views.MyTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/dialog_group_message_send_desc"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:lineSpacingExtra="@dimen/small_margin"
+    android:paddingLeft="@dimen/big_margin"
+    android:paddingTop="@dimen/big_margin"
+    android:paddingRight="@dimen/big_margin"
+    android:paddingBottom="@dimen/activity_margin"
+    android:text="@string/group_message_send_description"
+    android:textIsSelectable="true"
+    android:textSize="@dimen/bigger_text_size" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,6 +104,10 @@
     <string name="mms_file_size_limit_none">No limit</string>
     <string name="outgoing_messages">Outgoing messages</string>
     <string name="group_message_mms">Send group messages as MMS</string>
+    <string name="send_group_message">Group message format</string>
+    <string name="group_message_send_description">Group MMS keeps replies in one conversation, but carrier charges may apply. Sending separately sends one message to each person. You can change this later in app settings.</string>
+    <string name="group_mms">Group MMS</string>
+    <string name="separate_messages">Send separately</string>
     <string name="send_long_message_mms">Send long messages as MMS</string>
     <!-- Export / Import -->
     <string name="messages">Messages</string>


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Added a confirmation dialog to choose between "Group MMS" and "Send separately" when sending message in a group after first install

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Tested on clean install, dialog appeared and choice worked 

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

- Closes https://github.com/FossifyOrg/Messages/issues/52

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
