### PR TITLE
fix: pass participant numbers when relaunching new group thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a group message format choice on the first group send ([#52])
 
 ### Fixed
+- Fixed group message creation on Xiaomi devices ([#41])
 - Partially fixed issue with sending MMS images ([#45])
 
 ## [1.8.1] - 2026-07-09

--- a/app/src/main/kotlin/org/fossify/messages/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/org/fossify/messages/activities/ThreadActivity.kt
@@ -534,24 +534,26 @@ class ThreadActivity : SimpleActivity() {
 
             if (participants.isEmpty()) {
                 val name = intent.getStringExtra(THREAD_TITLE) ?: ""
-                val number = intent.getStringExtra(THREAD_NUMBER)
-                if (number == null) {
+                val numbers = getPhoneNumbersFromIntent()
+                if (numbers.isEmpty()) {
                     toast(org.fossify.commons.R.string.unknown_error_occurred)
                     finish()
                     return@ensureBackgroundThread
                 }
 
-                val phoneNumber = PhoneNumber(number, 0, "", number)
-                val contact = SimpleContact(
-                    rawId = 0,
-                    contactId = 0,
-                    name = name,
-                    photoUri = "",
-                    phoneNumbers = arrayListOf(phoneNumber),
-                    birthdays = ArrayList(),
-                    anniversaries = ArrayList()
-                )
-                participants.add(contact)
+                numbers.forEach { number ->
+                    val phoneNumber = PhoneNumber(number, 0, "", number)
+                    val contact = SimpleContact(
+                        rawId = number.hashCode(),
+                        contactId = number.hashCode(),
+                        name = if (numbers.size == 1) name else number,
+                        photoUri = "",
+                        phoneNumbers = arrayListOf(phoneNumber),
+                        birthdays = ArrayList(),
+                        anniversaries = ArrayList()
+                    )
+                    participants.add(contact)
+                }
             }
 
             if (!isRecycleBin) {
@@ -931,6 +933,7 @@ class ThreadActivity : SimpleActivity() {
                     hideKeyboard()
                     Intent(this@ThreadActivity, ThreadActivity::class.java).apply {
                         putExtra(THREAD_ID, newThreadId)
+                        putExtra(THREAD_NUMBER, Gson().toJson(numbers))
                         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                         startActivity(this)
                     }


### PR DESCRIPTION
## Summary

Creating a group message no longer dead-ends with "An unknown error occurred" on devices whose telephony provider can't resolve participants for a freshly created thread id (the MIUI/Xiaomi failure in the report). When the add-contacts flow relaunches `ThreadActivity` with the new group's thread id, the intent now also carries the participant numbers (`putExtra(THREAD_NUMBER, Gson().toJson(numbers))`), and the empty-participants fallback in `setupThread` builds one participant per number via the existing `getPhoneNumbersFromIntent()` helper instead of reading a single plain-string extra.

## Why this matters

The reporter in #41 could not create any group message: the compose flow computed the new thread id, relaunched the thread screen with only `THREAD_ID`, MIUI's provider returned no participants for that id, and the fallback found no `THREAD_NUMBER` extra so it toasted the unknown-error message and closed the screen. The helper this fix routes through already parses both a plain number and a Gson JSON array, so single-recipient relaunches behave exactly as before; the toast-and-finish path still fires when no numbers are available at all.

## Testing

Traced both relaunch paths: existing single-number intents take the same one-participant branch as before, and the new group path round-trips the numbers through the JSON array format `getPhoneNumbersFromIntent()` already supports (`ThreadActivity.kt:1798`). Added the CHANGELOG "Fixed" entry per repo convention.

Fixes #41
