### PR TITLE
feat: add allowed keywords that override blocked keyword filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for allowed keywords that override blocked keyword filtering
 
 ## [1.9.1] - 2026-07-19
 ### Changed

--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -16,6 +16,7 @@
     <ID>EmptyFunctionBlock:ArchivedConversationsAdapter.kt$ArchivedConversationsAdapter${}</ID>
     <ID>EmptyFunctionBlock:BaseConversationsAdapter.kt$BaseConversationsAdapter${}</ID>
     <ID>EmptyFunctionBlock:ContactsAdapter.kt$ContactsAdapter${}</ID>
+    <ID>EmptyFunctionBlock:ManageAllowedKeywordsAdapter.kt$ManageAllowedKeywordsAdapter${}</ID>
     <ID>EmptyFunctionBlock:ManageBlockedKeywordsAdapter.kt$ManageBlockedKeywordsAdapter${}</ID>
     <ID>EmptyFunctionBlock:RecycleBinConversationsAdapter.kt$RecycleBinConversationsAdapter${}</ID>
     <ID>EmptyFunctionBlock:SearchResultsAdapter.kt$SearchResultsAdapter${}</ID>
@@ -148,6 +149,7 @@
     <ID>SpreadOperator:MainActivity.kt$MainActivity$(*currentMessages.toTypedArray())</ID>
     <ID>SpreadOperator:ThreadActivity.kt$ThreadActivity$(*currentMessages.toTypedArray())</ID>
     <ID>SwallowedException:ArchivedConversationsActivity.kt$ArchivedConversationsActivity$e: Exception</ID>
+    <ID>SwallowedException:AllowedKeywordsExporter.kt$AllowedKeywordsExporter$e: Exception</ID>
     <ID>SwallowedException:BlockedKeywordsExporter.kt$BlockedKeywordsExporter$e: Exception</ID>
     <ID>SwallowedException:ImageCompressor.kt$ImageCompressor$e: Exception</ID>
     <ID>SwallowedException:JsonElement.kt$e: Exception</ID>
@@ -167,6 +169,8 @@
     <ID>ThrowsCount:SmsSender.kt$SmsSender$fun sendMessage( subId: Int, destination: String, body: String, serviceCenter: String?, requireDeliveryReport: Boolean, messageUri: Uri )</ID>
     <ID>TooGenericExceptionCaught:Activity.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ArchivedConversationsActivity.kt$ArchivedConversationsActivity$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:AllowedKeywordsExporter.kt$AllowedKeywordsExporter$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:AllowedKeywordsImporter.kt$AllowedKeywordsImporter$e: Exception</ID>
     <ID>TooGenericExceptionCaught:BlockedKeywordsExporter.kt$BlockedKeywordsExporter$e: Exception</ID>
     <ID>TooGenericExceptionCaught:BlockedKeywordsImporter.kt$BlockedKeywordsImporter$e: Exception</ID>
     <ID>TooGenericExceptionCaught:Context.kt$e: Exception</ID>
@@ -174,6 +178,7 @@
     <ID>TooGenericExceptionCaught:ExportMessagesDialog.kt$ExportMessagesDialog$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:ImageCompressor.kt$ImageCompressor$e: Exception</ID>
     <ID>TooGenericExceptionCaught:JsonElement.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ManageAllowedKeywordsActivity.kt$ManageAllowedKeywordsActivity$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ManageBlockedKeywordsActivity.kt$ManageBlockedKeywordsActivity$e: Exception</ID>
     <ID>TooGenericExceptionCaught:MessagesImporter.kt$MessagesImporter$e: Exception</ID>
     <ID>TooGenericExceptionCaught:MessagesImporter.kt$MessagesImporter$e: Throwable</ID>
@@ -202,6 +207,8 @@
     <ID>TooManyFunctions:ConversationsDao.kt$ConversationsDao</ID>
     <ID>TooManyFunctions:JsonObject.kt$org.fossify.messages.extensions.gson.JsonObject.kt</ID>
     <ID>TooManyFunctions:MainActivity.kt$MainActivity : SimpleActivity</ID>
+    <ID>TooManyFunctions:ManageAllowedKeywordsActivity.kt$ManageAllowedKeywordsActivity : SimpleActivityRefreshRecyclerViewListener</ID>
+    <ID>TooManyFunctions:ManageAllowedKeywordsAdapter.kt$ManageAllowedKeywordsAdapter : MyRecyclerViewAdapter</ID>
     <ID>TooManyFunctions:ManageBlockedKeywordsActivity.kt$ManageBlockedKeywordsActivity : SimpleActivityRefreshRecyclerViewListener</ID>
     <ID>TooManyFunctions:ManageBlockedKeywordsAdapter.kt$ManageBlockedKeywordsAdapter : MyRecyclerViewAdapter</ID>
     <ID>TooManyFunctions:MessagesDao.kt$MessagesDao</ID>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -147,6 +147,13 @@
             android:parentActivityName=".activities.SettingsActivity" />
 
         <activity
+            android:name=".activities.ManageAllowedKeywordsActivity"
+            android:configChanges="orientation"
+            android:exported="false"
+            android:label="@string/allowed_keywords"
+            android:parentActivityName=".activities.SettingsActivity" />
+
+        <activity
             android:name=".activities.VCardViewerActivity"
             android:configChanges="orientation"
             android:exported="false"

--- a/app/src/main/kotlin/org/fossify/messages/activities/ManageAllowedKeywordsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/messages/activities/ManageAllowedKeywordsActivity.kt
@@ -1,0 +1,224 @@
+package org.fossify.messages.activities
+
+import android.content.ActivityNotFoundException
+import android.net.Uri
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import org.fossify.commons.extensions.beVisibleIf
+import org.fossify.commons.extensions.getProperPrimaryColor
+import org.fossify.commons.extensions.getTempFile
+import org.fossify.commons.extensions.showErrorToast
+import org.fossify.commons.extensions.toast
+import org.fossify.commons.extensions.underlineText
+import org.fossify.commons.extensions.updateTextColors
+import org.fossify.commons.extensions.viewBinding
+import org.fossify.commons.helpers.ExportResult
+import org.fossify.commons.helpers.NavigationIcon
+import org.fossify.commons.helpers.ensureBackgroundThread
+import org.fossify.commons.interfaces.RefreshRecyclerViewListener
+import org.fossify.messages.R
+import org.fossify.messages.databinding.ActivityManageAllowedKeywordsBinding
+import org.fossify.messages.dialogs.AddAllowedKeywordDialog
+import org.fossify.messages.dialogs.ExportAllowedKeywordsDialog
+import org.fossify.messages.dialogs.ManageAllowedKeywordsAdapter
+import org.fossify.messages.extensions.config
+import org.fossify.messages.extensions.toArrayList
+import org.fossify.messages.helpers.AllowedKeywordsExporter
+import org.fossify.messages.helpers.AllowedKeywordsImporter
+import java.io.FileOutputStream
+import java.io.OutputStream
+
+class ManageAllowedKeywordsActivity : SimpleActivity(), RefreshRecyclerViewListener {
+
+    private val binding by viewBinding(ActivityManageAllowedKeywordsBinding::inflate)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+        updateAllowedKeywords()
+        setupOptionsMenu()
+
+        setupEdgeToEdge(padBottomImeAndSystem = listOf(binding.manageAllowedKeywordsList))
+        setupMaterialScrollListener(
+            scrollingView = binding.manageAllowedKeywordsList,
+            topAppBar = binding.allowKeywordsAppbar
+        )
+        updateTextColors(binding.manageAllowedKeywordsWrapper)
+
+        binding.manageAllowedKeywordsPlaceholder2.apply {
+            underlineText()
+            setTextColor(getProperPrimaryColor())
+            setOnClickListener {
+                addOrEditAllowedKeyword()
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        setupTopAppBar(binding.allowKeywordsAppbar, NavigationIcon.Arrow)
+    }
+
+    private fun setupOptionsMenu() {
+        binding.allowKeywordsToolbar.setOnMenuItemClickListener { menuItem ->
+            when (menuItem.itemId) {
+                R.id.add_allowed_keyword -> {
+                    addOrEditAllowedKeyword()
+                    true
+                }
+
+                R.id.export_allowed_keywords -> {
+                    tryExportAllowedKeywords()
+                    true
+                }
+
+                R.id.import_allowed_keywords -> {
+                    tryImportAllowedKeywords()
+                    true
+                }
+
+                else -> false
+            }
+        }
+    }
+
+    private val createDocument =
+        registerForActivityResult(ActivityResultContracts.CreateDocument("text/plain")) { uri ->
+            try {
+                val outputStream = uri?.let { contentResolver.openOutputStream(it) }
+                if (outputStream != null) {
+                    exportAllowedKeywordsTo(outputStream)
+                }
+            } catch (e: Exception) {
+                showErrorToast(e)
+            }
+        }
+
+    private val getContent =
+        registerForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+            try {
+                if (uri != null) {
+                    tryImportAllowedKeywordsFromFile(uri)
+                }
+            } catch (e: Exception) {
+                showErrorToast(e)
+            }
+        }
+
+    private fun tryImportAllowedKeywords() {
+        val mimeType = "text/plain"
+        try {
+            getContent.launch(mimeType)
+        } catch (_: ActivityNotFoundException) {
+            toast(org.fossify.commons.R.string.system_service_disabled, Toast.LENGTH_LONG)
+        } catch (e: Exception) {
+            showErrorToast(e)
+        }
+    }
+
+    private fun tryImportAllowedKeywordsFromFile(uri: Uri) {
+        when (uri.scheme) {
+            "file" -> importAllowedKeywords(uri.path!!)
+            "content" -> {
+                val tempFile = getTempFile("allowed", "allowed_keywords.txt")
+                if (tempFile == null) {
+                    toast(org.fossify.commons.R.string.unknown_error_occurred)
+                    return
+                }
+
+                try {
+                    val inputStream = contentResolver.openInputStream(uri)
+                    val out = FileOutputStream(tempFile)
+                    inputStream!!.copyTo(out)
+                    importAllowedKeywords(tempFile.absolutePath)
+                } catch (e: Exception) {
+                    showErrorToast(e)
+                }
+            }
+
+            else -> toast(org.fossify.commons.R.string.invalid_file_format)
+        }
+    }
+
+    private fun importAllowedKeywords(path: String) {
+        ensureBackgroundThread {
+            val result = AllowedKeywordsImporter(this).importAllowedKeywords(path)
+            toast(
+                when (result) {
+                    AllowedKeywordsImporter.ImportResult.IMPORT_OK -> org.fossify.commons.R.string.importing_successful
+                    AllowedKeywordsImporter.ImportResult.IMPORT_FAIL -> org.fossify.commons.R.string.no_items_found
+                }
+            )
+            updateAllowedKeywords()
+        }
+    }
+
+    private fun exportAllowedKeywordsTo(outputStream: OutputStream?) {
+        ensureBackgroundThread {
+            val allowedKeywords = config.allowedKeywords.toArrayList()
+            if (allowedKeywords.isEmpty()) {
+                toast(org.fossify.commons.R.string.no_entries_for_exporting)
+            } else {
+                AllowedKeywordsExporter.exportAllowedKeywords(allowedKeywords, outputStream) {
+                    toast(
+                        when (it) {
+                            ExportResult.EXPORT_OK -> org.fossify.commons.R.string.exporting_successful
+                            else -> org.fossify.commons.R.string.exporting_failed
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    private fun tryExportAllowedKeywords() {
+        ExportAllowedKeywordsDialog(
+            activity = this,
+            path = config.lastAllowedKeywordExportPath,
+            hidePath = true
+        ) { file ->
+            try {
+                createDocument.launch(file.name)
+            } catch (_: ActivityNotFoundException) {
+                toast(
+                    org.fossify.commons.R.string.system_service_disabled,
+                    Toast.LENGTH_LONG
+                )
+            } catch (e: Exception) {
+                showErrorToast(e)
+            }
+        }
+    }
+
+    override fun refreshItems() {
+        updateAllowedKeywords()
+    }
+
+    private fun updateAllowedKeywords() {
+        ensureBackgroundThread {
+            val allowedKeywords = config.allowedKeywords.sorted().toArrayList()
+            runOnUiThread {
+                ManageAllowedKeywordsAdapter(
+                    activity = this,
+                    allowedKeywords = allowedKeywords,
+                    listener = this,
+                    recyclerView = binding.manageAllowedKeywordsList
+                ) {
+                    addOrEditAllowedKeyword(it as String)
+                }.apply {
+                    binding.manageAllowedKeywordsList.adapter = this
+                }
+
+                binding.manageAllowedKeywordsPlaceholder.beVisibleIf(allowedKeywords.isEmpty())
+                binding.manageAllowedKeywordsPlaceholder2.beVisibleIf(allowedKeywords.isEmpty())
+            }
+        }
+    }
+
+    private fun addOrEditAllowedKeyword(keyword: String? = null) {
+        AddAllowedKeywordDialog(this, keyword) {
+            updateAllowedKeywords()
+        }
+    }
+}

--- a/app/src/main/kotlin/org/fossify/messages/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/messages/activities/SettingsActivity.kt
@@ -106,6 +106,7 @@ class SettingsActivity : SimpleActivity() {
         setupLanguage()
         setupManageBlockedNumbers()
         setupManageBlockedKeywords()
+        setupManageAllowedKeywords()
         setupChangeDateTimeFormat()
         setupFontSize()
         setupShowCharacterCounter()
@@ -222,6 +223,21 @@ class SettingsActivity : SimpleActivity() {
         settingsManageBlockedKeywordsHolder.setOnClickListener {
             if (isOrWasThankYouInstalled()) {
                 Intent(this@SettingsActivity, ManageBlockedKeywordsActivity::class.java).apply {
+                    startActivity(this)
+                }
+            } else {
+                FeatureLockedDialog(this@SettingsActivity) { }
+            }
+        }
+    }
+
+    private fun setupManageAllowedKeywords() = binding.apply {
+        settingsManageAllowedKeywords.text =
+            addLockedLabelIfNeeded(R.string.manage_allowed_keywords)
+
+        settingsManageAllowedKeywordsHolder.setOnClickListener {
+            if (isOrWasThankYouInstalled()) {
+                Intent(this@SettingsActivity, ManageAllowedKeywordsActivity::class.java).apply {
                     startActivity(this)
                 }
             } else {

--- a/app/src/main/kotlin/org/fossify/messages/dialogs/AddAllowedKeywordDialog.kt
+++ b/app/src/main/kotlin/org/fossify/messages/dialogs/AddAllowedKeywordDialog.kt
@@ -1,0 +1,46 @@
+package org.fossify.messages.dialogs
+
+import androidx.appcompat.app.AlertDialog
+import org.fossify.commons.activities.BaseSimpleActivity
+import org.fossify.commons.extensions.getAlertDialogBuilder
+import org.fossify.commons.extensions.setupDialogStuff
+import org.fossify.commons.extensions.showKeyboard
+import org.fossify.commons.extensions.value
+import org.fossify.messages.databinding.DialogAddAllowedKeywordBinding
+import org.fossify.messages.extensions.config
+
+class AddAllowedKeywordDialog(
+    val activity: BaseSimpleActivity,
+    private val originalKeyword: String? = null,
+    val callback: () -> Unit
+) {
+    init {
+        val binding = DialogAddAllowedKeywordBinding.inflate(activity.layoutInflater).apply {
+            if (originalKeyword != null) {
+                addAllowedKeywordEdittext.setText(originalKeyword)
+            }
+        }
+
+        activity.getAlertDialogBuilder()
+            .setPositiveButton(org.fossify.commons.R.string.ok, null)
+            .setNegativeButton(org.fossify.commons.R.string.cancel, null)
+            .apply {
+                activity.setupDialogStuff(binding.root, this) { alertDialog ->
+                    alertDialog.showKeyboard(binding.addAllowedKeywordEdittext)
+                    alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                        val newAllowedKeyword = binding.addAllowedKeywordEdittext.value
+                        if (originalKeyword != null && newAllowedKeyword != originalKeyword) {
+                            activity.config.removeAllowedKeyword(originalKeyword)
+                        }
+
+                        if (newAllowedKeyword.isNotEmpty()) {
+                            activity.config.addAllowedKeyword(newAllowedKeyword)
+                        }
+
+                        callback()
+                        alertDialog.dismiss()
+                    }
+                }
+            }
+    }
+}

--- a/app/src/main/kotlin/org/fossify/messages/dialogs/ExportAllowedKeywordsDialog.kt
+++ b/app/src/main/kotlin/org/fossify/messages/dialogs/ExportAllowedKeywordsDialog.kt
@@ -1,0 +1,90 @@
+package org.fossify.messages.dialogs
+
+import androidx.appcompat.app.AlertDialog
+import org.fossify.commons.activities.BaseSimpleActivity
+import org.fossify.commons.dialogs.FilePickerDialog
+import org.fossify.commons.extensions.beGone
+import org.fossify.commons.extensions.getAlertDialogBuilder
+import org.fossify.commons.extensions.getCurrentFormattedDateTime
+import org.fossify.commons.extensions.getParentPath
+import org.fossify.commons.extensions.humanizePath
+import org.fossify.commons.extensions.internalStoragePath
+import org.fossify.commons.extensions.isAValidFilename
+import org.fossify.commons.extensions.setupDialogStuff
+import org.fossify.commons.extensions.showKeyboard
+import org.fossify.commons.extensions.toast
+import org.fossify.commons.extensions.value
+import org.fossify.commons.helpers.ensureBackgroundThread
+import org.fossify.messages.R
+import org.fossify.messages.databinding.DialogExportAllowedKeywordsBinding
+import org.fossify.messages.extensions.config
+import org.fossify.messages.helpers.ALLOWED_KEYWORDS_EXPORT_EXTENSION
+import java.io.File
+
+class ExportAllowedKeywordsDialog(
+    val activity: BaseSimpleActivity,
+    val path: String,
+    val hidePath: Boolean,
+    callback: (file: File) -> Unit,
+) {
+    private var realPath = path.ifEmpty { activity.internalStoragePath }
+    private val config = activity.config
+
+    init {
+        val view =
+            DialogExportAllowedKeywordsBinding.inflate(activity.layoutInflater, null, false).apply {
+                exportAllowedKeywordsFolder.text = activity.humanizePath(realPath)
+                exportAllowedKeywordsFilename.setText(
+                    "${activity.getString(R.string.allowed_keywords)}_${activity.getCurrentFormattedDateTime()}"
+                )
+
+                if (hidePath) {
+                    exportAllowedKeywordsFolderLabel.beGone()
+                    exportAllowedKeywordsFolder.beGone()
+                } else {
+                    exportAllowedKeywordsFolder.setOnClickListener {
+                        FilePickerDialog(activity, realPath, false, showFAB = true) {
+                            exportAllowedKeywordsFolder.text = activity.humanizePath(it)
+                            realPath = it
+                        }
+                    }
+                }
+            }
+
+        activity.getAlertDialogBuilder()
+            .setPositiveButton(org.fossify.commons.R.string.ok, null)
+            .setNegativeButton(org.fossify.commons.R.string.cancel, null)
+            .apply {
+                activity.setupDialogStuff(
+                    view = view.root,
+                    dialog = this,
+                    titleId = R.string.export_allowed_keywords
+                ) { alertDialog ->
+                    alertDialog.showKeyboard(view.exportAllowedKeywordsFilename)
+                    alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                        val filename = view.exportAllowedKeywordsFilename.value
+                        when {
+                            filename.isEmpty() -> activity.toast(org.fossify.commons.R.string.empty_name)
+                            filename.isAValidFilename() -> {
+                                val file =
+                                    File(realPath, "$filename$ALLOWED_KEYWORDS_EXPORT_EXTENSION")
+                                if (!hidePath && file.exists()) {
+                                    activity.toast(org.fossify.commons.R.string.name_taken)
+                                    return@setOnClickListener
+                                }
+
+                                ensureBackgroundThread {
+                                    config.lastAllowedKeywordExportPath =
+                                        file.absolutePath.getParentPath()
+                                    callback(file)
+                                    alertDialog.dismiss()
+                                }
+                            }
+
+                            else -> activity.toast(org.fossify.commons.R.string.invalid_name)
+                        }
+                    }
+                }
+            }
+    }
+}

--- a/app/src/main/kotlin/org/fossify/messages/dialogs/ManageAllowedKeywordsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/messages/dialogs/ManageAllowedKeywordsAdapter.kt
@@ -1,0 +1,155 @@
+package org.fossify.messages.dialogs
+
+import android.view.ContextThemeWrapper
+import android.view.Gravity
+import android.view.Menu
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.widget.PopupMenu
+import org.fossify.commons.activities.BaseSimpleActivity
+import org.fossify.commons.adapters.MyRecyclerViewAdapter
+import org.fossify.commons.extensions.copyToClipboard
+import org.fossify.commons.extensions.getPopupMenuTheme
+import org.fossify.commons.extensions.getProperTextColor
+import org.fossify.commons.extensions.setupViewBackground
+import org.fossify.commons.interfaces.RefreshRecyclerViewListener
+import org.fossify.commons.views.MyRecyclerView
+import org.fossify.messages.R
+import org.fossify.messages.databinding.ItemManageBlockedKeywordBinding
+import org.fossify.messages.extensions.config
+
+class ManageAllowedKeywordsAdapter(
+    activity: BaseSimpleActivity,
+    var allowedKeywords: ArrayList<String>,
+    val listener: RefreshRecyclerViewListener?,
+    recyclerView: MyRecyclerView,
+    itemClick: (Any) -> Unit
+) : MyRecyclerViewAdapter(activity, recyclerView, itemClick) {
+    init {
+        setupDragListener(true)
+    }
+
+    override fun getActionMenuId() = R.menu.cab_allowed_keywords
+
+    override fun prepareActionMode(menu: Menu) {
+        menu.apply {
+            findItem(R.id.cab_copy_keyword).isVisible = isOneItemSelected()
+        }
+    }
+
+    override fun actionItemPressed(id: Int) {
+        if (selectedKeys.isEmpty()) {
+            return
+        }
+
+        when (id) {
+            R.id.cab_copy_keyword -> copyKeywordToClipboard()
+            R.id.cab_delete -> deleteSelection()
+        }
+    }
+
+    override fun getSelectableItemCount() = allowedKeywords.size
+
+    override fun getIsItemSelectable(position: Int) = true
+
+    override fun getItemSelectionKey(position: Int) = allowedKeywords.getOrNull(position)?.hashCode()
+
+    override fun getItemKeyPosition(key: Int) = allowedKeywords.indexOfFirst { it.hashCode() == key }
+
+    override fun onActionModeCreated() {}
+
+    override fun onActionModeDestroyed() {}
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemManageBlockedKeywordBinding.inflate(layoutInflater, parent, false)
+        return createViewHolder(binding.root)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val allowedKeyword = allowedKeywords[position]
+        holder.bindView(allowedKeyword, allowSingleClick = true, allowLongClick = true) { itemView, _ ->
+            setupView(itemView, allowedKeyword)
+        }
+        bindViewHolder(holder)
+    }
+
+    override fun getItemCount() = allowedKeywords.size
+
+    private fun getSelectedItems() = allowedKeywords.filter { selectedKeys.contains(it.hashCode()) }
+
+    private fun setupView(view: View, allowedKeyword: String) {
+        ItemManageBlockedKeywordBinding.bind(view).apply {
+            root.setupViewBackground(activity)
+            manageBlockedKeywordHolder.isSelected = selectedKeys.contains(allowedKeyword.hashCode())
+            manageBlockedKeywordTitle.apply {
+                text = allowedKeyword
+                setTextColor(textColor)
+            }
+
+            overflowMenuIcon.drawable.apply {
+                mutate()
+                setTint(activity.getProperTextColor())
+            }
+
+            overflowMenuIcon.setOnClickListener {
+                showPopupMenu(overflowMenuAnchor, allowedKeyword)
+            }
+        }
+    }
+
+    private fun showPopupMenu(view: View, allowedKeyword: String) {
+        finishActMode()
+        val theme = activity.getPopupMenuTheme()
+        val contextTheme = ContextThemeWrapper(activity, theme)
+
+        PopupMenu(contextTheme, view, Gravity.END).apply {
+            inflate(getActionMenuId())
+            setOnMenuItemClickListener { item ->
+                val allowedKeywordId = allowedKeyword.hashCode()
+                when (item.itemId) {
+                    R.id.cab_copy_keyword -> {
+                        executeItemMenuOperation(allowedKeywordId) {
+                            copyKeywordToClipboard()
+                        }
+                    }
+
+                    R.id.cab_delete -> {
+                        executeItemMenuOperation(allowedKeywordId) {
+                            deleteSelection()
+                        }
+                    }
+                }
+                true
+            }
+            show()
+        }
+    }
+
+    private fun executeItemMenuOperation(allowedKeywordId: Int, callback: () -> Unit) {
+        selectedKeys.add(allowedKeywordId)
+        callback()
+        selectedKeys.remove(allowedKeywordId)
+    }
+
+    private fun copyKeywordToClipboard() {
+        val selectedKeyword = getSelectedItems().firstOrNull() ?: return
+        activity.copyToClipboard(selectedKeyword)
+        finishActMode()
+    }
+
+    private fun deleteSelection() {
+        val deleteAllowedKeywords = HashSet<String>(selectedKeys.size)
+        val positions = getSelectedItemPositions()
+
+        getSelectedItems().forEach {
+            deleteAllowedKeywords.add(it)
+            activity.config.removeAllowedKeyword(it)
+        }
+
+        allowedKeywords.removeAll(deleteAllowedKeywords)
+        removeSelectedItems(positions)
+        if (allowedKeywords.isEmpty()) {
+            listener?.refreshItems()
+        }
+    }
+}

--- a/app/src/main/kotlin/org/fossify/messages/helpers/AllowedKeywordsExporter.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/AllowedKeywordsExporter.kt
@@ -1,0 +1,29 @@
+package org.fossify.messages.helpers
+
+import org.fossify.commons.helpers.ExportResult
+import java.io.OutputStream
+
+object AllowedKeywordsExporter {
+
+    fun exportAllowedKeywords(
+        allowedKeywords: ArrayList<String>,
+        outputStream: OutputStream?,
+        callback: (result: ExportResult) -> Unit,
+    ) {
+        if (outputStream == null) {
+            callback.invoke(ExportResult.EXPORT_FAIL)
+            return
+        }
+
+        try {
+            outputStream.bufferedWriter().use { out ->
+                out.write(allowedKeywords.joinToString(ALLOWED_KEYWORDS_EXPORT_DELIMITER) {
+                    it
+                })
+            }
+            callback.invoke(ExportResult.EXPORT_OK)
+        } catch (e: Exception) {
+            callback.invoke(ExportResult.EXPORT_FAIL)
+        }
+    }
+}

--- a/app/src/main/kotlin/org/fossify/messages/helpers/AllowedKeywordsImporter.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/AllowedKeywordsImporter.kt
@@ -1,0 +1,35 @@
+package org.fossify.messages.helpers
+
+import android.app.Activity
+import org.fossify.commons.extensions.showErrorToast
+import org.fossify.messages.extensions.config
+import java.io.File
+
+class AllowedKeywordsImporter(
+    private val activity: Activity,
+) {
+    enum class ImportResult {
+        IMPORT_FAIL, IMPORT_OK
+    }
+
+    fun importAllowedKeywords(path: String): ImportResult {
+        return try {
+            val inputStream = File(path).inputStream()
+            val keywords = inputStream.bufferedReader().use {
+                val content = it.readText().trimEnd().split(ALLOWED_KEYWORDS_EXPORT_DELIMITER)
+                content
+            }
+            if (keywords.isNotEmpty()) {
+                keywords.forEach { keyword: String ->
+                    activity.config.addAllowedKeyword(keyword)
+                }
+                ImportResult.IMPORT_OK
+            } else {
+                ImportResult.IMPORT_FAIL
+            }
+        } catch (e: Exception) {
+            activity.showErrorToast(e)
+            ImportResult.IMPORT_FAIL
+        }
+    }
+}

--- a/app/src/main/kotlin/org/fossify/messages/helpers/Config.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/Config.kt
@@ -91,6 +91,18 @@ class Config(context: Context) : BaseConfig(context) {
         blockedKeywords = blockedKeywords.minus(keyword)
     }
 
+    var allowedKeywords: Set<String>
+        get() = prefs.getStringSet(ALLOWED_KEYWORDS, HashSet<String>())!!
+        set(allowedKeywords) = prefs.edit().putStringSet(ALLOWED_KEYWORDS, allowedKeywords).apply()
+
+    fun addAllowedKeyword(keyword: String) {
+        allowedKeywords = allowedKeywords.plus(keyword)
+    }
+
+    fun removeAllowedKeyword(keyword: String) {
+        allowedKeywords = allowedKeywords.minus(keyword)
+    }
+
     var exportSms: Boolean
         get() = prefs.getBoolean(EXPORT_SMS, true)
         set(exportSms) = prefs.edit().putBoolean(EXPORT_SMS, exportSms).apply()
@@ -146,6 +158,11 @@ class Config(context: Context) : BaseConfig(context) {
         get() = prefs.getString(LAST_BLOCKED_KEYWORD_EXPORT_PATH, "")!!
         set(lastBlockedNumbersExportPath) = prefs.edit()
             .putString(LAST_BLOCKED_KEYWORD_EXPORT_PATH, lastBlockedNumbersExportPath).apply()
+
+    var lastAllowedKeywordExportPath: String
+        get() = prefs.getString(LAST_ALLOWED_KEYWORD_EXPORT_PATH, "")!!
+        set(lastAllowedKeywordExportPath) = prefs.edit()
+            .putString(LAST_ALLOWED_KEYWORD_EXPORT_PATH, lastAllowedKeywordExportPath).apply()
 
     var keepConversationsArchived: Boolean
         get() = prefs.getBoolean(KEEP_CONVERSATIONS_ARCHIVED, false)

--- a/app/src/main/kotlin/org/fossify/messages/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/Constants.kt
@@ -26,7 +26,9 @@ const val SEND_GROUP_MESSAGE_MMS = "send_group_message_mms"
 const val MMS_FILE_SIZE_LIMIT = "mms_file_size_limit"
 const val PINNED_CONVERSATIONS = "pinned_conversations"
 const val BLOCKED_KEYWORDS = "blocked_keywords"
+const val ALLOWED_KEYWORDS = "allowed_keywords"
 const val LAST_BLOCKED_KEYWORD_EXPORT_PATH = "last_blocked_keyword_export_path"
+const val LAST_ALLOWED_KEYWORD_EXPORT_PATH = "last_allowed_keyword_export_path"
 const val EXPORT_SMS = "export_sms"
 const val EXPORT_MMS = "export_mms"
 const val JSON_FILE_EXTENSION = ".json"
@@ -99,6 +101,8 @@ const val PICK_SAVE_DIR_INTENT = 50
 
 const val BLOCKED_KEYWORDS_EXPORT_DELIMITER = ","
 const val BLOCKED_KEYWORDS_EXPORT_EXTENSION = ".txt"
+const val ALLOWED_KEYWORDS_EXPORT_DELIMITER = ","
+const val ALLOWED_KEYWORDS_EXPORT_EXTENSION = ".txt"
 
 fun refreshMessages() {
     EventBus.getDefault().post(Events.RefreshMessages())

--- a/app/src/main/kotlin/org/fossify/messages/helpers/ReceiverUtils.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/ReceiverUtils.kt
@@ -6,6 +6,12 @@ import org.fossify.messages.extensions.config
 object ReceiverUtils {
 
     fun isMessageFilteredOut(context: Context, body: String): Boolean {
+        for (allowedKeyword in context.config.allowedKeywords) {
+            if (body.contains(allowedKeyword, ignoreCase = true)) {
+                return false
+            }
+        }
+
         for (blockedKeyword in context.config.blockedKeywords) {
             if (body.contains(blockedKeyword, ignoreCase = true)) {
                 return true

--- a/app/src/main/res/layout/activity_manage_allowed_keywords.xml
+++ b/app/src/main/res/layout/activity_manage_allowed_keywords.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/allow_keywords_coordinator"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <org.fossify.commons.views.MyAppBarLayout
+        android:id="@+id/allow_keywords_appbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/allow_keywords_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/color_primary"
+            app:menu="@menu/menu_add_allowed_keyword"
+            app:title="@string/manage_allowed_keywords"
+            app:titleTextAppearance="@style/AppTheme.ActionBar.TitleTextStyle" />
+
+    </org.fossify.commons.views.MyAppBarLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/manage_allowed_keywords_wrapper"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <org.fossify.commons.views.MyRecyclerView
+            android:id="@+id/manage_allowed_keywords_list"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:clipToPadding="false"
+            android:scrollbars="vertical"
+            app:layoutManager="org.fossify.commons.views.MyLinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:listitem="@layout/item_manage_blocked_keyword" />
+
+        <org.fossify.commons.views.MyTextView
+            android:id="@+id/manage_allowed_keywords_placeholder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:alpha="0.8"
+            android:gravity="center_horizontal"
+            android:paddingStart="@dimen/activity_margin"
+            android:paddingTop="@dimen/activity_margin"
+            android:paddingEnd="@dimen/activity_margin"
+            android:text="@string/not_allowing_keywords"
+            android:textSize="@dimen/bigger_text_size"
+            android:textStyle="italic"
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <org.fossify.commons.views.MyTextView
+            android:id="@+id/manage_allowed_keywords_placeholder_2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/ripple_all_corners"
+            android:gravity="center"
+            android:padding="@dimen/activity_margin"
+            android:text="@string/add_an_allowed_keyword"
+            android:textSize="@dimen/bigger_text_size"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/manage_allowed_keywords_placeholder" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -159,6 +159,21 @@
             </RelativeLayout>
 
             <RelativeLayout
+                android:id="@+id/settings_manage_allowed_keywords_holder"
+                style="@style/SettingsHolderTextViewOneLinerStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <org.fossify.commons.views.MyTextView
+                    android:id="@+id/settings_manage_allowed_keywords"
+                    style="@style/SettingsTextLabelStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/manage_allowed_keywords" />
+
+            </RelativeLayout>
+
+            <RelativeLayout
                 android:id="@+id/settings_font_size_holder"
                 style="@style/SettingsHolderTextViewStyle"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/dialog_add_allowed_keyword.xml
+++ b/app/src/main/res/layout/dialog_add_allowed_keyword.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/dialog_holder"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="@dimen/activity_margin">
+
+    <org.fossify.commons.views.MyTextInputLayout
+        android:id="@+id/add_allowed_keyword_hint"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/activity_margin"
+        android:layout_marginEnd="@dimen/activity_margin"
+        android:hint="@string/keyword">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/add_allowed_keyword_edittext"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text"
+            android:textCursorDrawable="@null"
+            android:textSize="@dimen/bigger_text_size" />
+
+    </org.fossify.commons.views.MyTextInputLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/dialog_export_allowed_keywords.xml
+++ b/app/src/main/res/layout/dialog_export_allowed_keywords.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/export_allowed_keywords_wrapper"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/export_allowed_keywords_holder"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingLeft="@dimen/activity_margin"
+        android:paddingTop="@dimen/activity_margin"
+        android:paddingRight="@dimen/activity_margin">
+
+        <org.fossify.commons.views.MyTextView
+            android:id="@+id/export_allowed_keywords_folder_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/small_margin"
+            android:text="@string/folder"
+            android:textSize="@dimen/smaller_text_size" />
+
+        <org.fossify.commons.views.MyTextView
+            android:id="@+id/export_allowed_keywords_folder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/small_margin"
+            android:paddingStart="@dimen/small_margin"
+            android:paddingTop="@dimen/small_margin"
+            android:paddingBottom="@dimen/activity_margin" />
+
+        <org.fossify.commons.views.MyTextInputLayout
+            android:id="@+id/export_allowed_keywords_hint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/filename_without_txt">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/export_allowed_keywords_filename"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/activity_margin"
+                android:singleLine="true"
+                android:textCursorDrawable="@null"
+                android:textSize="@dimen/normal_text_size" />
+
+        </org.fossify.commons.views.MyTextInputLayout>
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/menu/cab_allowed_keywords.xml
+++ b/app/src/main/res/menu/cab_allowed_keywords.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/cab_copy_keyword"
+        android:icon="@drawable/ic_copy_vector"
+        android:title="@string/copy_to_clipboard"
+        app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/cab_delete"
+        android:icon="@drawable/ic_delete_vector"
+        android:title="@string/delete"
+        app:showAsAction="ifRoom" />
+</menu>

--- a/app/src/main/res/menu/menu_add_allowed_keyword.xml
+++ b/app/src/main/res/menu/menu_add_allowed_keyword.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/add_allowed_keyword"
+        android:icon="@drawable/ic_plus_vector"
+        android:title="@string/add_an_allowed_keyword"
+        app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/import_allowed_keywords"
+        android:title="@string/import_allowed_keywords"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/export_allowed_keywords"
+        android:title="@string/export_allowed_keywords"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,10 @@
     <string name="manage_blocked_keywords">Manage blocked keywords</string>
     <string name="not_blocking_keywords">You are not blocking any keywords. You may add keywords here to block all messages containing them.</string>
     <string name="add_a_blocked_keyword">Add a blocked keyword</string>
+    <string name="allowed_keywords">Allowed keywords</string>
+    <string name="manage_allowed_keywords">Manage allowed keywords</string>
+    <string name="not_allowing_keywords">You are not allowing any keywords. You may add phrases here to allow messages that would otherwise be blocked.</string>
+    <string name="add_an_allowed_keyword">Add an allowed keyword</string>
     <string name="lock_screen_visibility">Lock screen notification visibility</string>
     <string name="sender_and_message">Sender and message</string>
     <string name="sender_only">Sender only</string>
@@ -121,6 +125,8 @@
     <string name="no_option_selected">You have to select at least one item</string>
     <string name="export_blocked_keywords">Export blocked keywords</string>
     <string name="import_blocked_keywords">Import blocked keywords</string>
+    <string name="export_allowed_keywords">Export allowed keywords</string>
+    <string name="import_allowed_keywords">Import allowed keywords</string>
     <!-- Errors -->
     <string name="empty_destination_address">Can\'t send message to an empty number</string>
     <string name="unable_to_save_message">Unable to save message to the telephony database</string>


### PR DESCRIPTION
## Summary
Blocked keywords currently filter any message whose body contains a matching phrase, with no way to allow specific exceptions. For example, blocking `money` also blocks messages containing `money data`.

This PR adds **Allowed keywords**: phrases that keep a message even when a blocked keyword also matches. The manage UI, storage, and import/export mirror the existing blocked-keywords flow for consistency.

Closes #807

## Behavior
Incoming SMS/MMS bodies are evaluated as:

1. If the body contains any **allowed** keyword → keep the message
2. Else if the body contains any **blocked** keyword → filter it out
3. Else → keep the message

Matching uses the same case-insensitive substring check as blocked keywords (`contains(..., ignoreCase = true)`).

| Setup | Message body | Result |
| --- | --- | --- |
| Block `money` | `Send money now` | Filtered |
| Block `money`, allow `money data` | `Your money data report` | Kept |
| Block `money`, allow `money data` | `Send money now` | Filtered |
| Allow only (no overlapping block) | Normal SMS | Unchanged |

## Changes
- Add `allowedKeywords` prefs API in `Config` / `Constants`
- Update `ReceiverUtils.isMessageFilteredOut` (allow-then-block)
- Add Settings entry: **Manage allowed keywords** (same Thank You / feature lock as blocked keywords)
- Add manage screen with add/edit/delete + import/export
- English strings only (translations via Weblate)
- Changelog entry under `[Unreleased]`
- Detekt baseline updates for the new mirrored classes

## Screenshots

<table>
  <tr>
    <td align="center"><b>Settings</b></td>
    <td align="center"><b>Empty state</b></td>
    <td align="center"><b>Allowed keyword list</b></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/dfed9967-e436-4f67-b505-44960692999e" width="280" /></td>
    <td><img src="https://github.com/user-attachments/assets/4738c09e-8f11-459e-b502-9f861c685f0b" width="280" /></td>
    <td><img src="https://github.com/user-attachments/assets/3e41a304-77a1-493a-aa35-b486586be414" width="280" /></td>
  </tr>
  <tr>
    <td align="center"><b>Add keyword dialog</b></td>
    <td align="center"><b>Blocked keywords</b></td>
    <td align="center"><b>Filtering test</b></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/31d29b92-6d34-4dbe-a93c-385ad4d3e8e5" width="280" /></td>
    <td><img src="https://github.com/user-attachments/assets/0db3eeaf-438d-4e6b-81d7-ced561d660e2" width="280" /></td>
    <td><img src="https://github.com/user-attachments/assets/f6117ea1-a749-4a65-9ea5-adbb4b2026d5" width="280" /></td>
  </tr>
</table>

## Test plan
- [ ] Block `money` only → messages containing `money` are filtered; unrelated SMS still arrive
- [ ] Add allowed keyword `money data` → messages containing `money data` arrive; messages with only `money` still filtered
- [ ] Allowed keyword alone (no overlapping block) does not change non-blocked messages
- [ ] Add / edit / delete allowed keywords; empty list shows placeholder
- [ ] Import / export round-trip of allowed keywords
- [ ] Feature lock still applies when Fossify Thank You is not installed
- [ ] MMS body filtering follows the same allow-then-block rules
- [ ] UI checked on Light / Dark / Black & White / System default
- [ ] UI checked with largest system font size
- [ ] CI checks pass (build, lint, detekt)

## Notes
- No translated `values-*/strings.xml` files were changed; English only, per Fossify translation guidelines
- Scope is limited to this feature (no unrelated refactors)