### PR TITLE
fix: secure notification action receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed exposed action receivers for security ([#834])
+- Fixed incorrect SMS/MMS deletion from notifications in rare cases
 
 ## [1.9.1] - 2026-07-19
 ### Changed
@@ -271,6 +274,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#651]: https://github.com/FossifyOrg/Messages/issues/651
 [#713]: https://github.com/FossifyOrg/Messages/issues/713
 [#829]: https://github.com/FossifyOrg/Messages/issues/829
+[#834]: https://github.com/FossifyOrg/Messages/issues/834
 
 [Unreleased]: https://github.com/FossifyOrg/Messages/compare/1.9.1...HEAD
 [1.9.1]: https://github.com/FossifyOrg/Messages/compare/1.9.0...1.9.1

--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -8,7 +8,7 @@
     <ID>CyclomaticComplexMethod:ConversationsAdapter.kt$ConversationsAdapter$override fun actionItemPressed(id: Int)</ID>
     <ID>CyclomaticComplexMethod:MainActivity.kt$MainActivity$private fun getNewConversations(cachedConversations: ArrayList&lt;Conversation&gt;)</ID>
     <ID>CyclomaticComplexMethod:MessagesImporter.kt$MessagesImporter$private fun InputStream.importXml()</ID>
-    <ID>CyclomaticComplexMethod:NotificationHelper.kt$NotificationHelper$@SuppressLint("NewApi") fun showMessageNotification( messageId: Long, address: String, body: String, threadId: Long, bitmap: Bitmap?, sender: String?, alertOnlyOnce: Boolean = false )</ID>
+    <ID>CyclomaticComplexMethod:NotificationHelper.kt$NotificationHelper$@SuppressLint("NewApi") fun showMessageNotification( messageId: Long, isMms: Boolean, address: String, body: String, threadId: Long, bitmap: Bitmap?, sender: String?, alertOnlyOnce: Boolean = false )</ID>
     <ID>CyclomaticComplexMethod:ThreadActivity.kt$ThreadActivity$private fun refreshMenuItems()</ID>
     <ID>CyclomaticComplexMethod:ThreadActivity.kt$ThreadActivity$private fun setupButtons()</ID>
     <ID>CyclomaticComplexMethod:ThreadActivity.kt$ThreadActivity$private fun setupThread(callback: () -&gt; Unit)</ID>
@@ -25,7 +25,7 @@
     <ID>ForbiddenComment:SmsStatusDeliveredReceiver.kt$SmsStatusDeliveredReceiver$// TODO: Need to check whether SC still trying to deliver the SMS to destination and will send the report again?</ID>
     <ID>FunctionParameterNaming:Config.kt$Config$SIMId: Int</ID>
     <ID>LargeClass:ThreadActivity.kt$ThreadActivity : SimpleActivity</ID>
-    <ID>LongMethod:NotificationHelper.kt$NotificationHelper$@SuppressLint("NewApi") fun showMessageNotification( messageId: Long, address: String, body: String, threadId: Long, bitmap: Bitmap?, sender: String?, alertOnlyOnce: Boolean = false )</ID>
+    <ID>LongMethod:NotificationHelper.kt$NotificationHelper$@SuppressLint("NewApi") fun showMessageNotification( messageId: Long, isMms: Boolean, address: String, body: String, threadId: Long, bitmap: Bitmap?, sender: String?, alertOnlyOnce: Boolean = false )</ID>
     <ID>MagicNumber:Activity.kt$1000000</ID>
     <ID>MagicNumber:BaseConversationsAdapter.kt$BaseConversationsAdapter$0.7f</ID>
     <ID>MagicNumber:BaseConversationsAdapter.kt$BaseConversationsAdapter$0.8f</ID>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -215,29 +215,17 @@
         <receiver
             android:name=".receivers.MarkAsReadReceiver"
             android:enabled="true"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="org.fossify.messages.action.mark_as_read" />
-            </intent-filter>
-        </receiver>
+            android:exported="false" />
 
         <receiver
             android:name=".receivers.DirectReplyReceiver"
             android:enabled="true"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="org.fossify.messages.action.reply" />
-            </intent-filter>
-        </receiver>
+            android:exported="false" />
 
         <receiver
             android:name=".receivers.DeleteSmsReceiver"
             android:enabled="true"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="org.fossify.messages.action.delete" />
-            </intent-filter>
-        </receiver>
+            android:exported="false" />
 
         <receiver
             android:name=".receivers.ScheduledMessageReceiver"

--- a/app/src/main/kotlin/org/fossify/messages/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/messages/extensions/Context.kt
@@ -1061,6 +1061,7 @@ fun Context.getThreadId(addresses: Set<String>): Long {
 
 fun Context.showReceivedMessageNotification(
     messageId: Long,
+    isMms: Boolean,
     address: String,
     senderName: String,
     body: String,
@@ -1070,6 +1071,7 @@ fun Context.showReceivedMessageNotification(
     Handler(Looper.getMainLooper()).post {
         notificationHelper.showMessageNotification(
             messageId = messageId,
+            isMms = isMms,
             address = address,
             body = body,
             threadId = threadId,

--- a/app/src/main/kotlin/org/fossify/messages/helpers/NotificationHelper.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/NotificationHelper.kt
@@ -38,6 +38,7 @@ class NotificationHelper(private val context: Context) {
     @SuppressLint("NewApi")
     fun showMessageNotification(
         messageId: Long,
+        isMms: Boolean,
         address: String,
         body: String,
         threadId: Long,
@@ -74,19 +75,20 @@ class NotificationHelper(private val context: Context) {
                 context,
                 notificationId,
                 markAsReadIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
 
         val deleteSmsIntent = Intent(context, DeleteSmsReceiver::class.java).apply {
             putExtra(THREAD_ID, threadId)
             putExtra(MESSAGE_ID, messageId)
+            putExtra(IS_MMS, isMms)
         }
         val deleteSmsPendingIntent =
             PendingIntent.getBroadcast(
                 context,
                 notificationId,
                 deleteSmsIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
 
         var replyAction: NotificationCompat.Action? = null

--- a/app/src/main/kotlin/org/fossify/messages/receivers/DirectReplyReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/DirectReplyReceiver.kt
@@ -58,6 +58,7 @@ class DirectReplyReceiver : BroadcastReceiver() {
                 Handler(Looper.getMainLooper()).post {
                     context.notificationHelper.showMessageNotification(
                         messageId = messageId,
+                        isMms = false,
                         address = address,
                         body = body,
                         threadId = threadId,

--- a/app/src/main/kotlin/org/fossify/messages/receivers/MmsReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/MmsReceiver.kt
@@ -84,6 +84,7 @@ class MmsReceiver : MmsReceivedReceiver() {
 
         context.showReceivedMessageNotification(
             messageId = mms.id,
+            isMms = true,
             address = address,
             senderName = senderName,
             body = mms.body,

--- a/app/src/main/kotlin/org/fossify/messages/receivers/SmsReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/SmsReceiver.kt
@@ -145,6 +145,7 @@ class SmsReceiver : BroadcastReceiver() {
         refreshConversations()
         context.showReceivedMessageNotification(
             messageId = newMessageId,
+            isMms = false,
             address = address,
             senderName = senderName,
             body = body,


### PR DESCRIPTION
Make notification action receivers app-private and preserve the SMS/MMS type when deleting from a notification.

Closes #834.